### PR TITLE
Init mantle.common.operator

### DIFF
--- a/mantle/common/operator.py
+++ b/mantle/common/operator.py
@@ -1,5 +1,8 @@
+from functools import wraps
+
+
 from magma import *
-from mantle import And
+from mantle import And, NAnd, Or, NOr, XOr, NXOr
 
 def get_length(value):
     if isinstance(value, (BitType, ClockType, EnableType, ResetType)):
@@ -10,9 +13,49 @@ def get_length(value):
         raise NotImplementedError("Cannot get_length of"
                 " {}".format(type(value)))
 
+def check_operator_args(fn):
+    @wraps(fn)
+    def wrapped(*args, **kwargs):
+        if len(args) < 2:
+            raise RuntimeError("{} requires at least 2 arguments".format(fn.__name__))
+        width = get_length(args[0])
+        if not all(get_length(x) == width for x in args):
+            raise ValueError("All arguments should have the same length")
+        return fn(*args, **kwargs)
+    return wrapped
 
+
+@check_operator_args
 def and_(*args, **kwargs):
     width = get_length(args[0])
-    if not all(get_length(x) == width for x in args):
-        raise ValueError("All arguments should have the same length")
     return And(len(args), width, **kwargs)(*args)
+
+
+@check_operator_args
+def nand(*args, **kwargs):
+    width = get_length(args[0])
+    return NAnd(len(args), width, **kwargs)(*args)
+
+
+@check_operator_args
+def or_(*args, **kwargs):
+    width = get_length(args[0])
+    return Or(len(args), width, **kwargs)(*args)
+
+
+@check_operator_args
+def nor(*args, **kwargs):
+    width = get_length(args[0])
+    return NOr(len(args), width, **kwargs)(*args)
+
+
+@check_operator_args
+def xor(*args, **kwargs):
+    width = get_length(args[0])
+    return XOr(len(args), width, **kwargs)(*args)
+
+
+@check_operator_args
+def nxor(*args, **kwargs):
+    width = get_length(args[0])
+    return NXOr(len(args), width, **kwargs)(*args)

--- a/mantle/common/operator.py
+++ b/mantle/common/operator.py
@@ -1,0 +1,18 @@
+from magma import *
+from mantle import And
+
+def get_length(value):
+    if isinstance(value, (BitType, ClockType, EnableType, ResetType)):
+        return None
+    elif isinstance(value, ArrayType):
+        return len(value)
+    else:
+        raise NotImplementedError("Cannot get_length of"
+                " {}".format(type(value)))
+
+
+def and_(*args, **kwargs):
+    width = get_length(args[0])
+    if not all(get_length(x) == width for x in args):
+        raise ValueError("All arguments should have the same length")
+    return And(len(args), width, **kwargs)(*args)

--- a/mantle/coreir/logic.py
+++ b/mantle/coreir/logic.py
@@ -91,13 +91,6 @@ def ReduceAnd(height=2, **kwargs):
     return uncurry(And(height, **kwargs), prefix="in")
 
 
-def and_(*args, **kwargs):
-    width = get_length(args[0])
-    if not all(get_length(x) == width for x in args):
-        raise ValueError("All arguments should have the same length")
-    return And(len(args), width, **kwargs)(*args)
-
-
 @cache_definition
 def DefineNAnd(height=2, width=None):
     if width is None:
@@ -126,13 +119,6 @@ def NAnd(height, width=None, **kwargs):
 
 def ReduceNAnd(height=2, **kwargs):
     return uncurry(NAnd(height, **kwargs), prefix="in")
-
-
-def nand(*args, **kwargs):
-    width = get_length(args[0])
-    if not all(get_length(x) == width for x in args):
-        raise ValueError("All arguments should have the same length")
-    return NAnd(len(args), width, **kwargs)(*args)
 
 
 def simulate_bit_not(self, value_store, state_store):
@@ -181,13 +167,6 @@ def ReduceOr(height=2, **kwargs):
     return uncurry(Or(height, **kwargs), prefix="in")
 
 
-def or_(*args, **kwargs):
-    width = get_length(args[0])
-    if not all(get_length(x) == width for x in args):
-        raise ValueError("All arguments should have the same length")
-    return Or(len(args), width, **kwargs)(*args)
-
-
 @cache_definition
 def DefineNOr(height=2, width=None):
     if width is None:
@@ -218,13 +197,6 @@ def ReduceNOr(height=2, **kwargs):
     return uncurry(NOr(height, **kwargs), prefix="in")
 
 
-def nor(*args, **kwargs):
-    width = get_length(args[0])
-    if not all(get_length(x) == width for x in args):
-        raise ValueError("All arguments should have the same length")
-    return NOr(len(args), width, **kwargs)(*args)
-
-
 DefineCoreirXOr = declare_bits_binop("xor", operator.xor)
 
 
@@ -241,13 +213,6 @@ def DefineXOr(height=2, width=None):
 
 def XOr(height, width=None, **kwargs):
     return DefineXOr(height, width)(**kwargs)
-
-
-def xor(*args, **kwargs):
-    width = get_length(args[0])
-    if not all(get_length(x) == width for x in args):
-        raise ValueError("All arguments should have the same length")
-    return XOr(len(args), width, **kwargs)(*args)
 
 def ReduceXOr(height=2, **kwargs):
     return uncurry(XOr(height, **kwargs), prefix="in")
@@ -278,13 +243,6 @@ def DefineNXOr(height=2, width=None):
 
 def NXOr(height, width=None, **kwargs):
     return DefineXOr(height, width)(**kwargs)
-
-
-def nxor(*args, **kwargs):
-    width = get_length(args[0])
-    if not all(get_length(x) == width for x in args):
-        raise ValueError("All arguments should have the same length")
-    return NXOr(len(args), width, **kwargs)(*args)
 
 def ReduceNXOr(height=2, **kwargs):
     return uncurry(NXOr(height, **kwargs), prefix="in")

--- a/mantle/lattice/mantle40/logic.py
+++ b/mantle/lattice/mantle40/logic.py
@@ -110,6 +110,10 @@ def DefineNAnd(height=2, width=None):
             nandmxn = join(col(nandm, width))
             wire(def_.I0, nandmxn.I0)
             wire(def_.I1, nandmxn.I1)
+            if height >= 3:
+                wire(def_.I2, nandmxn.I2)
+            if height == 4:
+                wire(def_.I3, nandmxn.I3)
             wire(nandmxn.O, def_.O)
 
     return _NAnd
@@ -231,6 +235,10 @@ def DefineNOr(height=2, width=None):
             normxn = join(col(norm, width))
             wire(def_.I0, normxn.I0)
             wire(def_.I1, normxn.I1)
+            if height >= 3:
+                wire(def_.I2, normxn.I2)
+            if height == 4:
+                wire(def_.I3, normxn.I3)
             wire(normxn.O, def_.O)
 
     return _NOr
@@ -279,6 +287,10 @@ def DefineXOr(height=2, width=1):
             xormxn = join(col(xorm, width))
             wire(def_.I0, xormxn.I0)
             wire(def_.I1, xormxn.I1)
+            if height >= 3:
+                wire(def_.I2, xormxn.I2)
+            if height == 4:
+                wire(def_.I3, xormxn.I3)
             wire(xormxn.O, def_.O)
 
     return _XOr
@@ -327,6 +339,10 @@ def DefineNXOr(height=2, width=None):
             nxormxn = join(col(nxorm, width))
             wire(def_.I0, nxormxn.I0)
             wire(def_.I1, nxormxn.I1)
+            if height >= 3:
+                wire(def_.I2, nxormxn.I2)
+            if height == 4:
+                wire(def_.I3, nxormxn.I3)
             wire(nxormxn.O, def_.O)
 
     return _NXOr

--- a/mantle/lattice/mantle40/logic.py
+++ b/mantle/lattice/mantle40/logic.py
@@ -58,6 +58,10 @@ def DefineAnd(height=2, width=None):
             andmxn = join(col(andm, width))
             wire(def_.I0, andmxn.I0)
             wire(def_.I1, andmxn.I1)
+            if height >= 3:
+                wire(def_.I2, andmxn.I2)
+            if height == 4:
+                wire(def_.I3, andmxn.I3)
             wire(andmxn.O, def_.O)
 
     return _And
@@ -328,7 +332,7 @@ def DefineNXOr(height=2, width=None):
     return _NXOr
 
 def NXOr(height=2, width=None, **kwargs):
-    if width is None: 
+    if width is None:
         return NOrN(height, **kwargs)
     return DefineNXOr(height, width)(**kwargs)
 

--- a/mantle/lattice/mantle40/logic.py
+++ b/mantle/lattice/mantle40/logic.py
@@ -214,7 +214,7 @@ def DefineNOr(height=2, width=None):
     class _NOr(Circuit):
         assert height > 1 and height <= 4
 
-        name = 'Nor%dx%d' % (height, width)
+        name = 'NOr%dx%d' % (height, width)
 
         if   height == 2:
             IO  = ['I0', In(T), 'I1', In(T)]
@@ -226,7 +226,7 @@ def DefineNOr(height=2, width=None):
 
         @classmethod
         def definition(def_):
-            def orm(y):
+            def norm(y):
                 return NOrN(height, loc=(0,y/8, y%8))
             normxn = join(col(norm, width))
             wire(def_.I0, normxn.I0)
@@ -262,7 +262,7 @@ def DefineXOr(height=2, width=1):
     class _XOr(Circuit):
         assert height > 1 and height <= 4
 
-        name = 'Xor%dx%d' % (height, width)
+        name = 'XOr%dx%d' % (height, width)
 
         if   height == 2:
             IO  = ['I0', In(T), 'I1', In(T)]
@@ -310,7 +310,7 @@ def DefineNXOr(height=2, width=None):
     class _NXOr(Circuit):
         assert height > 1 and height <= 4
 
-        name = 'NXor%dx%d' % (height, width)
+        name = 'NXOr%dx%d' % (height, width)
 
         if   height == 2:
             IO  = ['I0', In(T), 'I1', In(T)]

--- a/tests/test_common/build/.gitignore
+++ b/tests/test_common/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/test_common/gold/test_and_2.v
+++ b/tests/test_common/gold/test_and_2.v
@@ -1,0 +1,18 @@
+module And2x4 (input [3:0] I0, input [3:0] I1, output [3:0] O);
+wire  inst0_O;
+wire  inst1_O;
+wire  inst2_O;
+wire  inst3_O;
+SB_LUT4 #(.LUT_INIT(16'h8888)) inst0 (.I0(I0[0]), .I1(I1[0]), .I2(1'b0), .I3(1'b0), .O(inst0_O));
+SB_LUT4 #(.LUT_INIT(16'h8888)) inst1 (.I0(I0[1]), .I1(I1[1]), .I2(1'b0), .I3(1'b0), .O(inst1_O));
+SB_LUT4 #(.LUT_INIT(16'h8888)) inst2 (.I0(I0[2]), .I1(I1[2]), .I2(1'b0), .I3(1'b0), .O(inst2_O));
+SB_LUT4 #(.LUT_INIT(16'h8888)) inst3 (.I0(I0[3]), .I1(I1[3]), .I2(1'b0), .I3(1'b0), .O(inst3_O));
+assign O = {inst3_O,inst2_O,inst1_O,inst0_O};
+endmodule
+
+module main (input [3:0] I0, input [3:0] I1, output [3:0] O);
+wire [3:0] inst0_O;
+And2x4 inst0 (.I0(I0), .I1(I1), .O(inst0_O));
+assign O = inst0_O;
+endmodule
+

--- a/tests/test_common/gold/test_and_3.v
+++ b/tests/test_common/gold/test_and_3.v
@@ -1,0 +1,18 @@
+module And3x4 (input [3:0] I0, input [3:0] I1, input [3:0] I2, output [3:0] O);
+wire  inst0_O;
+wire  inst1_O;
+wire  inst2_O;
+wire  inst3_O;
+SB_LUT4 #(.LUT_INIT(16'h8080)) inst0 (.I0(I0[0]), .I1(I1[0]), .I2(I2[0]), .I3(1'b0), .O(inst0_O));
+SB_LUT4 #(.LUT_INIT(16'h8080)) inst1 (.I0(I0[1]), .I1(I1[1]), .I2(I2[1]), .I3(1'b0), .O(inst1_O));
+SB_LUT4 #(.LUT_INIT(16'h8080)) inst2 (.I0(I0[2]), .I1(I1[2]), .I2(I2[2]), .I3(1'b0), .O(inst2_O));
+SB_LUT4 #(.LUT_INIT(16'h8080)) inst3 (.I0(I0[3]), .I1(I1[3]), .I2(I2[3]), .I3(1'b0), .O(inst3_O));
+assign O = {inst3_O,inst2_O,inst1_O,inst0_O};
+endmodule
+
+module main (input [3:0] I0, input [3:0] I1, input [3:0] I2, output [3:0] O);
+wire [3:0] inst0_O;
+And3x4 inst0 (.I0(I0), .I1(I1), .I2(I2), .O(inst0_O));
+assign O = inst0_O;
+endmodule
+

--- a/tests/test_common/test_operator.py
+++ b/tests/test_common/test_operator.py
@@ -49,30 +49,50 @@ EndCircuit()\
     assert check("test_and_3.v")
 
 def check_binary_operator(op, instance_op):
-    circ = DefineCircuit('main', "I0", In(Bits(4)), "I1", In(Bits(4)), "O",
-            Out(Bits(4)))
+    name = 'check_binary_{}'.format(op.__name__)
+    circ = DefineCircuit(name, "I0", In(Bits(4)), "I1", In(Bits(4)), "O", Out(Bits(4)))
     wire(op(circ.I0, circ.I1), circ.O)
     EndDefine()
     assert repr(circ) == """\
-main = DefineCircuit("main", "I0", In(Bits(4)), "I1", In(Bits(4)), "O", Out(Bits(4)))
-inst0 = {}2x4()
-wire(main.I0, inst0.I0)
-wire(main.I1, inst0.I1)
-wire(inst0.O, main.O)
+{name} = DefineCircuit("{name}", "I0", In(Bits(4)), "I1", In(Bits(4)), "O", Out(Bits(4)))
+inst0 = {instance_op}2x4()
+wire({name}.I0, inst0.I0)
+wire({name}.I1, inst0.I1)
+wire(inst0.O, {name}.O)
 EndCircuit()\
-""".format(instance_op)
+""".format(name=name, instance_op=instance_op)
+
+def check_operator_three_args(op, instance_op):
+    name = 'check_{}_three_args'.format(op.__name__)
+    circ = DefineCircuit(name, "I0", In(Bits(4)), "I1", In(Bits(4)),  "I2", In(Bits(4)), "O", Out(Bits(4)))
+    wire(op(circ.I0, circ.I1, circ.I2), circ.O)
+    EndDefine()
+    assert repr(circ) == """\
+{name} = DefineCircuit("{name}", "I0", In(Bits(4)), "I1", In(Bits(4)), "I2", In(Bits(4)), "O", Out(Bits(4)))
+inst0 = {instance_op}3x4()
+wire({name}.I0, inst0.I0)
+wire({name}.I1, inst0.I1)
+wire({name}.I2, inst0.I2)
+wire(inst0.O, {name}.O)
+EndCircuit()\
+""".format(name=name, instance_op=instance_op)
 
 def test_nand():
     check_binary_operator(nand, "NAnd")
+    check_operator_three_args(nand, "NAnd")
 
 def test_or():
     check_binary_operator(or_, "Or")
+    check_operator_three_args(or_, "Or")
 
 def test_nor():
     check_binary_operator(nor, "NOr")
+    check_operator_three_args(nor, "NOr")
 
 def test_xor():
     check_binary_operator(xor, "XOr")
+    check_operator_three_args(xor, "XOr")
 
 def test_nxor():
     check_binary_operator(nxor, "NXOr")
+    check_operator_three_args(nxor, "NXOr")

--- a/tests/test_common/test_operator.py
+++ b/tests/test_common/test_operator.py
@@ -2,7 +2,7 @@ from magma import *
 import os
 os.environ["MANTLE"] = "lattice"
 from magma.testing import check_files_equal
-from mantle.common.operator import and_
+from mantle.common.operator import and_, nand, or_, nor, xor, nxor
 
 def check(file_name):
     return check_files_equal(
@@ -47,3 +47,32 @@ EndCircuit()\
 
     compile("build/test_and_3", circ)
     assert check("test_and_3.v")
+
+def check_binary_operator(op, instance_op):
+    circ = DefineCircuit('main', "I0", In(Bits(4)), "I1", In(Bits(4)), "O",
+            Out(Bits(4)))
+    wire(op(circ.I0, circ.I1), circ.O)
+    EndDefine()
+    assert repr(circ) == """\
+main = DefineCircuit("main", "I0", In(Bits(4)), "I1", In(Bits(4)), "O", Out(Bits(4)))
+inst0 = {}2x4()
+wire(main.I0, inst0.I0)
+wire(main.I1, inst0.I1)
+wire(inst0.O, main.O)
+EndCircuit()\
+""".format(instance_op)
+
+def test_nand():
+    check_binary_operator(nand, "NAnd")
+
+def test_or():
+    check_binary_operator(or_, "Or")
+
+def test_nor():
+    check_binary_operator(nor, "NOr")
+
+def test_xor():
+    check_binary_operator(xor, "XOr")
+
+def test_nxor():
+    check_binary_operator(nxor, "NXOr")

--- a/tests/test_common/test_operator.py
+++ b/tests/test_common/test_operator.py
@@ -17,8 +17,6 @@ def test_and_2():
             Out(Bits(4)))
     wire(and_(circ.I0, circ.I1), circ.O)
     EndDefine()
-    compile("build/test_and_2", circ)
-    print(repr(circ))
     assert repr(circ) == """\
 main = DefineCircuit("main", "I0", In(Bits(4)), "I1", In(Bits(4)), "O", Out(Bits(4)))
 inst0 = And2x4()
@@ -28,6 +26,7 @@ wire(inst0.O, main.O)
 EndCircuit()\
 """
 
+    compile("build/test_and_2", circ)
     assert check("test_and_2.v")
 
 
@@ -36,8 +35,6 @@ def test_and_3():
             In(Bits(4)), "O", Out(Bits(4)))
     wire(and_(circ.I0, circ.I1, circ.I2), circ.O)
     EndDefine()
-    compile("build/test_and_3", circ)
-    print(repr(circ))
     assert repr(circ) == """\
 main = DefineCircuit("main", "I0", In(Bits(4)), "I1", In(Bits(4)), "I2", In(Bits(4)), "O", Out(Bits(4)))
 inst0 = And3x4()
@@ -48,4 +45,5 @@ wire(inst0.O, main.O)
 EndCircuit()\
 """
 
+    compile("build/test_and_3", circ)
     assert check("test_and_3.v")

--- a/tests/test_common/test_operator.py
+++ b/tests/test_common/test_operator.py
@@ -1,0 +1,51 @@
+from magma import *
+import os
+os.environ["MANTLE"] = "lattice"
+from magma.testing import check_files_equal
+from mantle.common.operator import and_
+
+def check(file_name):
+    return check_files_equal(
+        __file__,
+        "build/{}".format(file_name),
+        "gold/{}".format(file_name)
+    )
+
+
+def test_and_2():
+    circ = DefineCircuit('main', "I0", In(Bits(4)), "I1", In(Bits(4)), "O",
+            Out(Bits(4)))
+    wire(and_(circ.I0, circ.I1), circ.O)
+    EndDefine()
+    compile("build/test_and_2", circ)
+    print(repr(circ))
+    assert repr(circ) == """\
+main = DefineCircuit("main", "I0", In(Bits(4)), "I1", In(Bits(4)), "O", Out(Bits(4)))
+inst0 = And2x4()
+wire(main.I0, inst0.I0)
+wire(main.I1, inst0.I1)
+wire(inst0.O, main.O)
+EndCircuit()\
+"""
+
+    assert check("test_and_2.v")
+
+
+def test_and_3():
+    circ = DefineCircuit('main', "I0", In(Bits(4)), "I1", In(Bits(4)), "I2",
+            In(Bits(4)), "O", Out(Bits(4)))
+    wire(and_(circ.I0, circ.I1, circ.I2), circ.O)
+    EndDefine()
+    compile("build/test_and_3", circ)
+    print(repr(circ))
+    assert repr(circ) == """\
+main = DefineCircuit("main", "I0", In(Bits(4)), "I1", In(Bits(4)), "I2", In(Bits(4)), "O", Out(Bits(4)))
+inst0 = And3x4()
+wire(main.I0, inst0.I0)
+wire(main.I1, inst0.I1)
+wire(main.I2, inst0.I2)
+wire(inst0.O, main.O)
+EndCircuit()\
+"""
+
+    assert check("test_and_3.v")


### PR DESCRIPTION
`repr` is quite useful for checking these higher level mantle ops. Assuming that the lower level primitives are implemented/tested, we can just check that the operation construct the proper Python representation of the circuit. In this case, the `and_` operator instantiates a Mantle `And` and wires it up.