### PR TITLE
Common compatability changes

### DIFF
--- a/mantle/__init__.py
+++ b/mantle/__init__.py
@@ -16,3 +16,7 @@ else:
     from mantle.common import *
 
 
+A0 = 0xAAAA
+A1 = 0xCCCC
+A2 = 0xF0F0
+A3 = 0xFF00

--- a/mantle/common/ROM.py
+++ b/mantle/common/ROM.py
@@ -1,12 +1,12 @@
 from magma import Circuit, In, Out, Bits, wire, bits, uncurry, fork, cache_definition
 from magma.bitutils import int2seq
-from mantle import LUT4, Mux
+from mantle import LUT, Mux
 from .RAM import readport
 
 __all__  = ['DefineROM', 'ROM']
 
 def ROM4(data, i, width):
-    return fork([uncurry(LUT4(data[i][w])) for w in range(width)])
+    return fork([uncurry(LUT(data[i][w], 4)) for w in range(width)])
 
 def ROM4s(n, width, data):
     return [ROM4(data, i, width) for i in range(n//16)]

--- a/mantle/common/arbiter.py
+++ b/mantle/common/arbiter.py
@@ -1,5 +1,5 @@
 from magma import *
-from mantle import LUT2, Add, A0, A1
+from mantle import LUT, DefineAdd, A0, A1
 
 __all__ = ['DefineArbiter', 'Arbiter', 'arbiter']
 
@@ -17,9 +17,9 @@ def DefineArbiter(n):
         @classmethod
         def definition(Arb):
             ones = n * [1]
-            y = Add(n)(Arb.I, array(ones))  # y = x - 1
+            y = DefineAdd(n)()(Arb.I, array(ones))  # y = x - 1
             def a(y):
-                return LUT2(A0 & ~A1)
+                return LUT(A0 & ~A1, 2)
             arb = join(col(a, n))
             arb(Arb.I, y)
             wire(arb.O, Arb.O)

--- a/mantle/common/barrel.py
+++ b/mantle/common/barrel.py
@@ -1,6 +1,6 @@
 from magma import Circuit, Bit, Bits, In, Out, bits, wire, map_
 from magma.bitutils import log2
-from mantle import Mux2
+from mantle import Mux
 
 __all__ = ['DefineBarrel', 'Barrel', 'barrel']
 
@@ -13,9 +13,9 @@ def DefineBarrelShift(n, k):
         @classmethod
         def definition(io):
             Is = [io.I[i] for i in range(n)]
-            muxes = map_(Mux2, n)
+            muxes = map_(Mux(2), n)
             for i in range(n):
-                shifti = i - k 
+                shifti = i - k
                 I = bits([Is[i], Is[shifti] if shifti >= 0 else io.SI])
                 muxes[i]( I, io.S )
             for i in range(n):

--- a/mantle/common/counter.py
+++ b/mantle/common/counter.py
@@ -1,5 +1,5 @@
 from magma import *
-from mantle import And, Mux, Add
+from mantle import And, Mux, DefineAdd
 from .register import Register
 from .decode import Decode
 
@@ -21,7 +21,7 @@ def _CounterName(name, n, ce, r):
 # O : Out(UInt(n)), COUT : Out(Bit)
 #
 @cache_definition
-def DefineCounter(n, cin=False, cout=True, incr=1, next=False, 
+def DefineCounter(n, cin=False, cout=True, incr=1, next=False,
     has_ce=False, has_reset=False):
 
     name = _CounterName('Counter', n, has_ce, has_reset)
@@ -38,7 +38,7 @@ def DefineCounter(n, cin=False, cout=True, incr=1, next=False,
 
     Counter = DefineCircuit(name, *args)
 
-    add = Add(n, cin=cin, cout=cout)
+    add = DefineAdd(n, cin=cin, cout=cout)()
     reg = Register(n, has_ce=has_ce, has_reset=has_reset)
 
     wire( reg.O, add.I0 )
@@ -63,10 +63,10 @@ def DefineCounter(n, cin=False, cout=True, incr=1, next=False,
 
     return Counter
 
-def Counter(n, cin=False, cout=True, incr=1, next=False, 
+def Counter(n, cin=False, cout=True, incr=1, next=False,
              has_ce=False, has_reset=False, **kwargs):
     """Construct a n-bit up counter."""
-    return DefineUpCounter(n, cin=cin, cout=cout, incr=incr, next=next, 
+    return DefineUpCounter(n, cin=cin, cout=cout, incr=incr, next=next,
                has_ce=has_ce, has_reset=has_reset)(**kwargs)
 
 DefineUpCounter = DefineCounter
@@ -77,24 +77,24 @@ UpCounter = Counter
 #
 # O : Out(UInt(n)), COUT : Out(Bit)
 #
-def DefineDownCounter(n, cin=False, cout=True, decr=1, next=False, 
+def DefineDownCounter(n, cin=False, cout=True, decr=1, next=False,
     has_ce=False, has_reset=False):
     incr = (1 << n) - (decr)
-    return DefineCounter(n, cin=cin, cout=cout, incr=incr, next=False, 
+    return DefineCounter(n, cin=cin, cout=cout, incr=incr, next=False,
                has_ce=has_ce, has_reset=has_reset)
 
-def DownCounter(n, cin=False, cout=True, decr=1, next=False, 
+def DownCounter(n, cin=False, cout=True, decr=1, next=False,
     has_ce=False, has_reset=False, **kwargs):
-    return DefineDownCounter(n, cin=cin, cout=cout, decr=decr, next=next, 
+    return DefineDownCounter(n, cin=cin, cout=cout, decr=decr, next=next,
                has_ce=has_ce, has_reset=has_reset)(**kwargs)
-              
+
 
 #
 # Create an n-bit up-down counter.
 #
 # U : In(Bit), D : In(Bit), O : Out(UInt(n)), COUT : Out(Bit)
 #
-def DefineUpDownCounter(n, cout=True, next=False, 
+def DefineUpDownCounter(n, cout=True, next=False,
     has_ce=False, has_reset=False):
 
     name = _CounterName('UpDownCounter', n, has_ce, has_reset)
@@ -135,10 +135,10 @@ def DefineUpDownCounter(n, cout=True, next=False,
 
     return Counter
 
-def UpDownCounter(n, cout=True, next=False, 
+def UpDownCounter(n, cout=True, next=False,
                     has_ce=False, has_reset=False, **kwargs):
     """Construct an n-bit updown counter."""
-    return DefineUpDownCounter(n, cout=cout, next=next, 
+    return DefineUpDownCounter(n, cout=cout, next=next,
                  has_ce=has_ce, has_reset=has_reset)(**kwargs)
 
 

--- a/mantle/common/counterload.py
+++ b/mantle/common/counterload.py
@@ -1,5 +1,5 @@
 from magma import *
-from mantle import And, Mux, Add
+from mantle import And, Mux, DefineAdd
 from .register import Register
 from .decode import Decode
 
@@ -35,7 +35,7 @@ def DefineCounterLoad(n, cin=False, cout=True, incr=1, next=False, has_ce=False,
 
     Counter = DefineCircuit(name, *args)
 
-    add = Add(n, cin=cin, cout=cout)
+    add = DefineAdd(n, cin=cin, cout=cout)()
     mux = Mux(2, n)
     reg = Register(n, has_ce=has_ce, has_reset=has_reset)
 
@@ -65,10 +65,10 @@ def DefineCounterLoad(n, cin=False, cout=True, incr=1, next=False, has_ce=False,
 
     return Counter
 
-def CounterLoad(n, cin=False, cout=True, incr=1, 
+def CounterLoad(n, cin=False, cout=True, incr=1,
         has_ce=False, has_reset=False, **kwargs):
     """Construct a n-bit counter."""
-    return DefineCounterLoad(n, cin=cin, cout=cout, incr=incr, next=next, 
+    return DefineCounterLoad(n, cin=cin, cout=cout, incr=incr, next=next,
                has_ce=has_ce, has_reset=has_reset)(**kwargs)
 
 

--- a/mantle/common/decode.py
+++ b/mantle/common/decode.py
@@ -1,5 +1,5 @@
 from magma import uncurry
-from mantle import LUTN
+from mantle import LUT
 
 __all__  = ['Decode', 'decode']
 
@@ -17,7 +17,7 @@ def Decode(i, n, invert=False, **kwargs):
         m = 1 << n
         mask = (1 << m) - 1
         i = mask & (~i)
-    return uncurry(LUTN(i, n, **kwargs))
+    return uncurry(LUT(i, n, **kwargs))
 
 def decode(I, i, invert=False, **kwargs):
     return Decode(i, len(I), invert=invert, **kwargs)(I)

--- a/mantle/common/pipo.py
+++ b/mantle/common/pipo.py
@@ -1,5 +1,5 @@
 from magma import *
-from mantle import Mux2
+from mantle import Mux
 from .register import _RegisterName, Register
 
 __all__ = ['DefinePIPO', 'PIPO']
@@ -20,7 +20,7 @@ def DefinePIPO(n, init=0, has_ce=False, has_reset=False):
         @classmethod
         def definition(pipo):
             def mux2(y):
-                return curry(Mux2(), prefix='I')
+                return curry(Mux(2), prefix='I')
 
             mux = braid(col(mux2, n), forkargs=['S'])
             reg = Register(n, init=init, has_ce=has_ce, has_reset=has_reset)
@@ -36,4 +36,4 @@ def DefinePIPO(n, init=0, has_ce=False, has_reset=False):
 
 def PIPO(n, init=0, has_ce=False, has_reset=False, **kwargs):
     return DefinePIPO(n, init, has_ce, has_reset)(**kwargs)
-    
+

--- a/mantle/common/piso.py
+++ b/mantle/common/piso.py
@@ -1,5 +1,5 @@
 from magma import *
-from mantle import Mux2
+from mantle import Mux
 from .register import _RegisterName, Register, FFs
 
 __all__ = ['DefinePISO', 'PISO']
@@ -20,7 +20,7 @@ def DefinePISO(n, init=0, has_ce=False, has_reset=False):
         @classmethod
         def definition(piso):
             def mux2(y):
-                return curry(Mux2(), prefix='I')
+                return curry(Mux(2), prefix='I')
 
             mux = braid(col(mux2, n), forkargs=['S'])
             reg = Register(n, init, has_ce=has_ce, has_reset=has_reset)
@@ -36,4 +36,4 @@ def DefinePISO(n, init=0, has_ce=False, has_reset=False):
 
 def PISO(n, init=0, has_ce=False, has_reset=False, **kwargs):
     return DefinePISO(n, init, has_ce, has_reset)(**kwargs)
-    
+

--- a/mantle/coreir/__init__.py
+++ b/mantle/coreir/__init__.py
@@ -18,6 +18,7 @@ from .arith import (
 )
 
 from .FF import FF, DFF, DefineDFF
+from .LUT import LUT
 
 from .MUX import DefineMux, Mux
 from .memory import DefineRAM, DefineMemory

--- a/mantle/lattice/ice40/PLB.py
+++ b/mantle/lattice/ice40/PLB.py
@@ -11,12 +11,12 @@ __all__ += ['LUTS_PER_LOGICBLOCK', 'BITS_PER_LUT', 'LOG_BITS_PER_LUT']
 __all__ += ['SB_LUT4']
 __all__ += ['SB_CARRY']
 
-__all__ += ['SB_DFF',    'SB_DFFE', 
+__all__ += ['SB_DFF',    'SB_DFFE',
             'SB_DFFSR',  'SB_DFFESR',
             'SB_DFFSS',  'SB_DFFESS',
             'SB_DFFR',   'SB_DFFER',
             'SB_DFFS',   'SB_DFFES',
-            'SB_DFFN',   'SB_DFFNE', 
+            'SB_DFFN',   'SB_DFFNE',
             'SB_DFFNSR', 'SB_DFFNESR',
             'SB_DFFNSS', 'SB_DFFNESS',
             'SB_DFFNR',  'SB_DFFNER',
@@ -40,8 +40,8 @@ I2 = A2
 I3 = A3
 
 ALL = A0 & A1 & A2 & A3
-ANY = A0 | A1 | A2 | A3 
-PARITY = A0 ^ A1 ^ A2 ^ A3 
+ANY = A0 | A1 | A2 | A3
+PARITY = A0 ^ A1 ^ A2 ^ A3
 
 SB_LUT4 = DeclareCircuit('SB_LUT4',
                "I0", In(Bit),
@@ -51,7 +51,7 @@ SB_LUT4 = DeclareCircuit('SB_LUT4',
                "O",  Out(Bit),
                stateful=False,
                simulate=simulate_sb_lut4,
-               coreir_lib="ice40") 
+               coreir_lib="ice40")
 
 # Implements (I0&I1)|(I1&I2)|(I2&I0)
 SB_CARRY = DeclareCircuit('SB_CARRY',
@@ -61,7 +61,7 @@ SB_CARRY = DeclareCircuit('SB_CARRY',
                "CO", Out(Bit),
                stateful=False,
                simulate=simulate_sb_carry,
-               coreir_lib="ice40") 
+               coreir_lib="ice40")
 
 # Positive edge versions
 
@@ -87,7 +87,7 @@ SB_DFFE = DeclareCircuit('SB_DFFE',
 # DFF w/ Synchronous Reset
 SB_DFFSR = DeclareCircuit('SB_DFFSR',
                "C", In(Clock),
-               "R", In(Reset), 
+               "R", In(Reset),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
@@ -97,17 +97,17 @@ SB_DFFSR = DeclareCircuit('SB_DFFSR',
 # DFF w/ Asynchronous Reset
 SB_DFFR = DeclareCircuit('SB_DFFR',
                "C", In(Clock),
-               "R", In(Reset), 
+               "R", In(Reset),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
                simulate=gen_sb_dff_sim(ce=False, sy=False, r=True, s=False, n=False),
                coreir_lib="ice40")
-    
+
 # DFF w/ Synchronous Set
 SB_DFFSS = DeclareCircuit('SB_DFFSS',
                "C", In(Clock),
-               "S", In(Bit), 
+               "S", In(Bit),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
@@ -117,18 +117,18 @@ SB_DFFSS = DeclareCircuit('SB_DFFSS',
 # DFF w/ Asynchronous Set
 SB_DFFS = DeclareCircuit('SB_DFFS',
                "C", In(Clock),
-               "S", In(Bit), 
+               "S", In(Bit),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
                simulate=gen_sb_dff_sim(ce=False, sy=False, r=False, s=True, n=False),
                coreir_lib="ice40")
-    
+
 # DFF w/ Synchronous Reset, Clock enable
 SB_DFFESR = DeclareCircuit('SB_DFFESR',
                "C", In(Clock),
-               "R", In(Reset), 
-               "E", In(Enable), 
+               "R", In(Reset),
+               "E", In(Enable),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
@@ -138,19 +138,19 @@ SB_DFFESR = DeclareCircuit('SB_DFFESR',
 # DFF w/ Asynchronous Reset, Clock enable
 SB_DFFER = DeclareCircuit('SB_DFFER',
                "C", In(Clock),
-               "R", In(Reset), 
-               "E", In(Enable), 
+               "R", In(Reset),
+               "E", In(Enable),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
                simulate=gen_sb_dff_sim(ce=True, sy=False, r=True, s=False, n=False),
                coreir_lib="ice40")
-    
+
 # DFF w/ Synchronous Set, Clock enable
 SB_DFFESS = DeclareCircuit('SB_DFFESS',
                "C", In(Clock),
-               "S", In(Bit), 
-               "E", In(Enable), 
+               "S", In(Bit),
+               "E", In(Enable),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
@@ -160,8 +160,8 @@ SB_DFFESS = DeclareCircuit('SB_DFFESS',
 # DFF w/ Asynchronous Set, Clock enable
 SB_DFFES = DeclareCircuit('SB_DFFES',
                "C", In(Clock),
-               "S", In(Bit), 
-               "E", In(Enable), 
+               "S", In(Bit),
+               "E", In(Enable),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
@@ -190,7 +190,7 @@ SB_DFFNE = DeclareCircuit('SB_DFFNE',
 # DFFN w/ Synchronous Reset
 SB_DFFNSR = DeclareCircuit('SB_DFFNSR',
                "C", In(Clock),
-               "R", In(Reset), 
+               "R", In(Reset),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
@@ -200,17 +200,17 @@ SB_DFFNSR = DeclareCircuit('SB_DFFNSR',
 # DFFN w/ Asynchronous Reset
 SB_DFFNR = DeclareCircuit('SB_DFFNR',
                "C", In(Clock),
-               "R", In(Reset), 
+               "R", In(Reset),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
                simulate=gen_sb_dff_sim(ce=False, sy=False, r=True, s=False, n=True),
                coreir_lib="ice40")
-    
+
 # DFFN w/ Synchronous Set
 SB_DFFNSS = DeclareCircuit('SB_DFFNSS',
                "C", In(Clock),
-               "S", In(Bit), 
+               "S", In(Bit),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
@@ -220,18 +220,18 @@ SB_DFFNSS = DeclareCircuit('SB_DFFNSS',
 # DFFN w/ Asynchronous Set
 SB_DFFNS = DeclareCircuit('SB_DFFNS',
                "C", In(Clock),
-               "S", In(Bit), 
+               "S", In(Bit),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
                simulate=gen_sb_dff_sim(ce=False, sy=False, r=False, s=True, n=True),
                coreir_lib="ice40")
-    
+
 # DFFN w/ Synchronous Reset, Clock enable
 SB_DFFNESR = DeclareCircuit('SB_DFFNESR',
                "C", In(Clock),
-               "R", In(Reset), 
-               "E", In(Enable), 
+               "R", In(Reset),
+               "E", In(Enable),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
@@ -241,19 +241,19 @@ SB_DFFNESR = DeclareCircuit('SB_DFFNESR',
 # DFFN w/ Asynchronous Reset, Clock enable
 SB_DFFNER = DeclareCircuit('SB_DFFNER',
                "C", In(Clock),
-               "R", In(Reset), 
-               "E", In(Enable), 
+               "R", In(Reset),
+               "E", In(Enable),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
                simulate=gen_sb_dff_sim(ce=True, sy=False, r=True, s=False, n=True),
                coreir_lib="ice40")
-    
+
 # DFFN w/ Synchronous Set, Clock enable
 SB_DFFNESS = DeclareCircuit('SB_DFFNESS',
                "C", In(Clock),
-               "S", In(Bit), 
-               "E", In(Enable), 
+               "S", In(Bit),
+               "E", In(Enable),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,
@@ -263,8 +263,8 @@ SB_DFFNESS = DeclareCircuit('SB_DFFNESS',
 # DFFN w/ Asynchronous Set, Clock enable
 SB_DFFNES = DeclareCircuit('SB_DFFNES',
                "C", In(Clock),
-               "S", In(Bit), 
-               "E", In(Enable), 
+               "S", In(Bit),
+               "E", In(Enable),
                "D", In(Bit),
                "Q", Out(Bit),
                stateful=True,

--- a/mantle/lattice/mantle40/LUT.py
+++ b/mantle/lattice/mantle40/LUT.py
@@ -24,18 +24,18 @@ def LUT1(rom, **kwargs):
     wire(0, lut.I1)
     wire(0, lut.I2)
     wire(0, lut.I3)
-    return AnonymousCircuit("I0", lut.I0, "O", lut.O) 
+    return AnonymousCircuit("I0", lut.I0, "O", lut.O)
 
 def LUT2(rom, **kwargs):
     lut = SB_LUT4(LUT_INIT=(lutinit(rom,1<<2)[0], 16), **kwargs)
     wire(0, lut.I2)
     wire(0, lut.I3)
-    return AnonymousCircuit("I0", lut.I0, "I1", lut.I1, "O", lut.O) 
+    return AnonymousCircuit("I0", lut.I0, "I1", lut.I1, "O", lut.O)
 
 def LUT3(rom, **kwargs):
     lut = SB_LUT4(LUT_INIT=(lutinit(rom,1<<3)[0], 16), **kwargs)
     wire(0, lut.I3)
-    return AnonymousCircuit("I0", lut.I0, "I1", lut.I1, "I2", lut.I2, "O", lut.O) 
+    return AnonymousCircuit("I0", lut.I0, "I1", lut.I1, "I2", lut.I2, "O", lut.O)
 
 def LUT4(rom, **kwargs):
     return SB_LUT4(LUT_INIT=lutinit(rom,1<<4), **kwargs)


### PR DESCRIPTION
Changes common circuits to use generic implementations (e.g. `LUT2 -> LUT(2)`). This enables common to work with the coreir implementation because it does not enumerate all the specialized variants.  I believe this shouldn't change the lattice implementations because `LUT(2)` just dispatches to `LUT2`.