### PR TITLE
Add coroutine based tests for common.Counter

### DIFF
--- a/mantle/common/counter.py
+++ b/mantle/common/counter.py
@@ -1,5 +1,5 @@
 from magma import *
-from mantle import And, Mux, DefineAdd
+from mantle import And, Mux, DefineAdd, Add
 from .register import Register
 from .decode import Decode
 

--- a/tests/test_common/test_counter.py
+++ b/tests/test_common/test_counter.py
@@ -32,6 +32,10 @@ def coroutine(func):
 
         def __next__(self):
             return next(self.co)
+
+        def next(self):
+            return self.__next__()
+
     return Coroutine
 
 

--- a/tests/test_common/test_counter.py
+++ b/tests/test_common/test_counter.py
@@ -44,7 +44,6 @@ def check(circuit, sim, number_of_cycles):
         # Coroutine has an implicit __next__ call on construction so it already
         # is init it's initial state
         assert sim.O == BitVector(simulator.get_value(circuit.O)).as_int()
-        print(sim.O)
         next(sim)
 
 
@@ -69,7 +68,6 @@ def down_counter4_sim():
         yield O
         for i in range((1<<4) - 1, 0, -1):
             O = i
-            print(O)
             yield O
 
 

--- a/tests/test_common/test_counter.py
+++ b/tests/test_common/test_counter.py
@@ -1,0 +1,58 @@
+from magma import *
+from magma.simulator import PythonSimulator
+from magma.bit_vector import BitVector
+import os
+os.environ["MANTLE"] = "lattice"
+from mantle.common import DefineCounter
+import types
+
+
+def coroutine(func):
+    class Coroutine:
+        """
+        Makes the initial call to __next__ upon construction to immediately
+        start the routine.
+
+        Overrides __getattr__ to support inspection of the local variables
+        """
+        def __init__(self, *args, **kwargs):
+            self.definition = func
+            self.reset(*args, **kwargs)
+
+        def reset(self, *args, **kwargs):
+            self.co = types.coroutine(self.definition)(*args, **kwargs)
+            next(self.co)
+
+        def __getattr__(self, key):
+            return self.co.gi_frame.f_locals[key]
+
+        def send(self, *args, **kwargs):
+            return self.co.send(*args, **kwargs)
+
+        def __next__(self):
+            return next(self.co)
+    return Coroutine
+
+
+def check(circuit, sim, number_of_cycles):
+    simulator = PythonSimulator(circuit, clock=circuit.CLK)
+    for cycle in range(number_of_cycles):
+        for i in range(2):
+            simulator.step()
+            simulator.evaluate()
+        assert sim.O == BitVector(simulator.get_value(circuit.O)).as_int()
+        print(sim.O)
+        next(sim)
+
+
+def test_counter():
+    Counter4 = DefineCounter(4)
+
+    @coroutine
+    def counter4_sim():
+        while True:
+            for i in range(0, 1<<4):
+                O = i
+                yield O
+
+    check(Counter4, counter4_sim(), 1<<4)

--- a/tests/test_common/test_counter.py
+++ b/tests/test_common/test_counter.py
@@ -40,6 +40,8 @@ def check(circuit, sim, number_of_cycles):
         for i in range(2):
             simulator.step()
             simulator.evaluate()
+        # Coroutine has an implicit __next__ call on construction so it already
+        # is init it's initial state
         assert sim.O == BitVector(simulator.get_value(circuit.O)).as_int()
         print(sim.O)
         next(sim)

--- a/tests/test_common/test_counter.py
+++ b/tests/test_common/test_counter.py
@@ -3,7 +3,7 @@ from magma.simulator import PythonSimulator
 from magma.bit_vector import BitVector
 import os
 os.environ["MANTLE"] = "lattice"
-from mantle.common import DefineCounter
+from mantle.common import DefineCounter, DefineDownCounter, DefineUpDownCounter
 import types
 
 
@@ -47,14 +47,32 @@ def check(circuit, sim, number_of_cycles):
         next(sim)
 
 
+@coroutine
+def counter4_sim():
+    while True:
+        for i in range(0, 1<<4):
+            O = i
+            yield O
+
+
 def test_counter():
     Counter4 = DefineCounter(4)
 
-    @coroutine
-    def counter4_sim():
-        while True:
-            for i in range(0, 1<<4):
-                O = i
-                yield O
+    check(Counter4, counter4_sim(), 1<<4 * 2)
 
-    check(Counter4, counter4_sim(), 1<<4)
+@coroutine
+def down_counter4_sim():
+    # Counter starts at 0, then counts down
+    while True:
+        O = 0
+        yield O
+        for i in range((1<<4) - 1, 0, -1):
+            O = i
+            print(O)
+            yield O
+
+
+def test_downcounter():
+    DownCounter4 = DefineDownCounter(4)
+
+    check(DownCounter4, down_counter4_sim(), 1<<4 * 2)

--- a/tests/test_common/test_counter.py
+++ b/tests/test_common/test_counter.py
@@ -1,54 +1,8 @@
 from magma import *
-from magma.simulator import PythonSimulator
-from magma.bit_vector import BitVector
+from magma.testing.coroutine import check, coroutine
 import os
 os.environ["MANTLE"] = "lattice"
 from mantle.common import DefineCounter, DefineDownCounter, DefineUpDownCounter
-# import types
-
-
-def coroutine(func):
-    class Coroutine:
-        """
-        Makes the initial call to __next__ upon construction to immediately
-        start the routine.
-
-        Overrides __getattr__ to support inspection of the local variables
-        """
-        def __init__(self, *args, **kwargs):
-            self.definition = func
-            self.reset(*args, **kwargs)
-
-        def reset(self, *args, **kwargs):
-            # self.co = types.coroutine(self.definition)(*args, **kwargs)
-            self.co = self.definition(*args, **kwargs)
-            next(self.co)
-
-        def __getattr__(self, key):
-            return self.co.gi_frame.f_locals[key]
-
-        def send(self, *args, **kwargs):
-            return self.co.send(*args, **kwargs)
-
-        def __next__(self):
-            return next(self.co)
-
-        def next(self):
-            return self.__next__()
-
-    return Coroutine
-
-
-def check(circuit, sim, number_of_cycles):
-    simulator = PythonSimulator(circuit, clock=circuit.CLK)
-    for cycle in range(number_of_cycles):
-        for i in range(2):
-            simulator.step()
-            simulator.evaluate()
-        # Coroutine has an implicit __next__ call on construction so it already
-        # is init it's initial state
-        assert sim.O == BitVector(simulator.get_value(circuit.O)).as_int()
-        next(sim)
 
 
 @coroutine

--- a/tests/test_common/test_counter.py
+++ b/tests/test_common/test_counter.py
@@ -4,7 +4,7 @@ from magma.bit_vector import BitVector
 import os
 os.environ["MANTLE"] = "lattice"
 from mantle.common import DefineCounter, DefineDownCounter, DefineUpDownCounter
-import types
+# import types
 
 
 def coroutine(func):
@@ -20,7 +20,8 @@ def coroutine(func):
             self.reset(*args, **kwargs)
 
         def reset(self, *args, **kwargs):
-            self.co = types.coroutine(self.definition)(*args, **kwargs)
+            # self.co = types.coroutine(self.definition)(*args, **kwargs)
+            self.co = self.definition(*args, **kwargs)
             next(self.co)
 
         def __getattr__(self, key):


### PR DESCRIPTION
Here's an example of using coroutines to test the counter modules in `mantle.common.counter`.

There will be some work needed to generalize this model to circuits with inputs, as well as circuits with multiple outputs.