### PR TITLE
Pass has_ce to the correct argument in ClockInterface

### DIFF
--- a/mantle/coreir/FF.py
+++ b/mantle/coreir/FF.py
@@ -111,7 +111,7 @@ def DefineCoreirReg(width, init=0, has_ce=False, has_reset=False, T=Bits):
 @cache_definition
 def DefineDFF(init=0, has_ce=False, has_reset=False):
     Reg = DefineCoreirReg(None, init, has_ce, has_reset)
-    IO = ["I", In(Bit), "O", Out(Bit)] + ClockInterface(has_ce, has_reset)
+    IO = ["I", In(Bit), "O", Out(Bit)] + ClockInterface(has_ce=has_ce, has_reset=has_reset)
     circ = DefineCircuit("DFF_init{}_has_ce{}_has_reset{}".format(init, has_ce, has_reset),
         *IO)
     reg = Reg()


### PR DESCRIPTION
The CoreIR backend was failing for has_ce=True because ClockInterface was getting the wrong arguments.
Updated the ClockInterface call to use keyword arguments.