### PR TITLE
Default CounterModM and Improved CoreIR Mem integration

### DIFF
--- a/mantle/common/countermod.py
+++ b/mantle/common/countermod.py
@@ -89,7 +89,7 @@ def SizedCounterModM(m, cin=False, cout=True, incr=1, next=False,
     :param kwargs: Args passed to the counter circuit when it is being initialized
     :return: A counter circuit
     """
-    return DefineCounterModM(m, math.ceil(math.log(m, 2)) + 1, cin, cout, incr, next, has_ce)(**kwargs)
+    return DefineCounterModM(m, math.ceil(math.log(m, 2)), cin, cout, incr, next, has_ce)(**kwargs)
 
 DefineUpCounterModM = DefineCounterModM
 UpCounterModM = CounterModM

--- a/mantle/common/countermod.py
+++ b/mantle/common/countermod.py
@@ -2,6 +2,7 @@ from magma import *
 from mantle import And
 from .decode import Decode
 from .counter import Counter
+import math
 
 __all__ = ['DefineUpCounterModM', 'UpCounterModM']
 #__all__ += ['DefineDownCounterModM', 'DownCounterModM']
@@ -74,6 +75,21 @@ def DefineCounterModM(m, n, cin=False, cout=True, incr=1, next=False,
 def CounterModM(m, n, cin=False, cout=True, incr=1, next=False,
     has_ce=False, **kwargs):
     return DefineCounterModM(m, n, cin, cout, incr, next, has_ce)(**kwargs)
+
+def SizedCounterModM(m, cin=False, cout=True, incr=1, next=False,
+    has_ce=False, **kwargs):
+    """
+    This is that counts from 0 to m - 1 that uses the minimum number of bits
+    :param m: The value the counter counts up to
+    :param cin: Whether this counter should have a carry input
+    :param cout: Whether this counter should a carry output
+    :param incr: How much this counter should increment by per clock. Default is 1.
+    :param next:
+    :param has_ce: Whether this counter should a clock-enable input
+    :param kwargs: Args passed to the counter circuit when it is being initialized
+    :return: A counter circuit
+    """
+    return DefineCounterModM(m, math.ceil(math.log(m, 2)) + 1, cin, cout, incr, next, has_ce)(**kwargs)
 
 DefineUpCounterModM = DefineCounterModM
 UpCounterModM = CounterModM

--- a/mantle/common/decode.py
+++ b/mantle/common/decode.py
@@ -20,10 +20,10 @@ def Decode(i, n, invert=False, **kwargs):
     @return: 1 if the n-bit input equals i
     """
 
-    assert n <= 8
-
     if os.getenv("MANTLE", "coreir") == "coreir":
         return DefineCoreIRDecode(i, n)()
+
+    assert n <= 8
     i = 1 << i
     if invert:
         m = 1 << n

--- a/mantle/coreir/memory.py
+++ b/mantle/coreir/memory.py
@@ -1,5 +1,6 @@
 from magma import *
 from magma.bit_vector import BitVector
+from magma.frontend.coreir_ import ModuleFromGeneratorWrapper
 
 
 def gen_sim_mem(depth, width):
@@ -33,7 +34,7 @@ def gen_sim_mem(depth, width):
 @cache_definition
 def DefineCoreirMem(depth, width):
     name = "coreir_mem{}x{}".format(depth,width)
-    addr_width = max((depth-1).bit_length(), 1)
+    addr_width = getRAMAddrWidth(depth)
     IO = ["raddr", In(Bits(addr_width)),
           "rdata", Out(Bits(width)),
           "waddr", In(Bits(addr_width)),
@@ -46,14 +47,22 @@ def DefineCoreirMem(depth, width):
             coreir_genargs={"width": width, "depth": depth})
             # coreir_configargs={"init": "0"})
 
+def CoreirMem(cirb, depth, width):
+    return ModuleFromGeneratorWrapper(cirb, "coreir", "mem", ["global"],
+                                      {"width": width, "depth": depth})
+
+
 def DefineROM(height, width):
     """
     coreir doesn't have a ROM primitive yet
     """
     raise NotImplementedError()
 
+def getRAMAddrWidth(height):
+    return max(height.bit_length(), 1)
+
 def DefineRAM(height, width):
-    addr_width = max(height.bit_length() - 1, 1)
+    addr_width = getRAMAddrWidth(height)
     circ = DefineCircuit("RAM{}x{}".format(height, width),
         "RADDR", In(Bits(addr_width)),
         "RDATA", Out(Bits(width)),

--- a/mantle/coreir/memory.py
+++ b/mantle/coreir/memory.py
@@ -51,7 +51,6 @@ def CoreirMem(cirb, depth, width):
     return ModuleFromGeneratorWrapper(cirb, "coreir", "mem", ["global"],
                                       {"width": width, "depth": depth})
 
-
 def DefineROM(height, width):
     """
     coreir doesn't have a ROM primitive yet


### PR DESCRIPTION
I added SizedCounterModM, a counterModM that automatically picks the minimum size of the counter necessary to account for the maximum value of M. As a front-end dev, I just want to be able to say "give me a counter that goes up to M" and not have to do the log math. This makes the optimal default decision w.r.t sizing.

I changed the decode max because, for the CoreIR case, there is no reason that only 8 bits can be used on an equality and constant. Is this assertion present because LUTs only have 8 bits for lookups in the FPGA boards we have been using?

I made a CoreIR circuit that automatically infers its ports using my new code. Should I remove the old version? It doesn't appear to be used anywhere else in the project. Also, I refactored out the getRAMAddrWidth so I can use it in my aetherling code, as I need to do the same calculations for my circuit sizes when using the RAM.
