### PR TITLE
Fixing Cout For CounterModM

### DIFF
--- a/mantle/common/countermod.py
+++ b/mantle/common/countermod.py
@@ -39,7 +39,7 @@ def DefineCounterModM(m, n, cin=False, cout=True, incr=1, next=False,
 
     CounterModM = DefineCircuit(name, *args)
 
-    counter = Counter(n, cin=cin, cout=cout, incr=incr, next=next,
+    counter = Counter(n, cin=cin, cout=False, incr=incr, next=next,
                    has_ce=has_ce, has_reset=True)
     reset = Decode(m - 1, n)(counter.O)
 

--- a/mantle/common/countermod.py
+++ b/mantle/common/countermod.py
@@ -8,9 +8,11 @@ __all__ = ['DefineUpCounterModM', 'UpCounterModM']
 #__all__ += ['DefineDownCounterModM', 'DownCounterModM']
 __all__ += ['DefineCounterModM', 'CounterModM', 'SizedCounterModM']
 
-def _CounterName(name, n, m, ce, r, s):
+def _CounterName(name, n, m, cin, cout, ce, r, s):
     name += '{}'.format(n)
     name += 'Mod{}'.format(m)
+    if cin: name += 'CIN'
+    if cout: name += 'COUT'
     if ce: name += 'CE'
     if r:  name += 'R'
     if s:  name += 'S'
@@ -25,7 +27,7 @@ def DefineCounterModM(m, n, cin=False, cout=True, incr=1, next=False,
 
     r = False
     s = False
-    name = _CounterName('Counter', n, m, has_ce, r, s)
+    name = _CounterName('Counter', n, m, cin, cout, has_ce, r, s)
 
     args = []
     if cin:

--- a/tests/test_coreir/test_arith.py
+++ b/tests/test_coreir/test_arith.py
@@ -3,13 +3,25 @@ from magma.testing import check_files_equal
 from mantle.coreir.arith import DefineAdd, DefineSub, DefineNegate, DefineASR
 from magma.testing.newfunction import testvectors as function_test
 from magma.simulator.python_simulator import testvectors as simulator_test
-
+from magma.simulator.coreir_simulator import CoreIRSimulator
 
 def test_add():
     width = 4
     mask = 2**width-1
     Add = DefineAdd(width)
     assert function_test(Add, lambda x, y: (x + y) & mask) == simulator_test(Add)
+
+def test_add_cout_one():
+    args = ['I0', In(Bits(1)), 'I1', In(Bits(1)), 'O', Out(Bits(1)), 'COUT',  Out(Bit)] + \
+        ClockInterface(False, False)
+    testcircuit = DefineCircuit('test_add_cout_one', *args)
+    add = DefineAdd(1, cout=True)()
+    wire(testcircuit.I0, add.I0)
+    wire(testcircuit.I1, add.I1)
+    wire(testcircuit.O, add.O)
+    wire(testcircuit.COUT, add.COUT)
+    EndCircuit()
+    sim = CoreIRSimulator(testcircuit, testcircuit.CLK)
 
 
 def test_add_cout_two():


### PR DESCRIPTION
CounterModM wasn't using cout and cin in the name, so caching was returning a version without cout when one with cout was asked for.