### PR TITLE
removed unnecessary assert in Decode

### DIFF
--- a/mantle/lattice/mantle40/decode.py
+++ b/mantle/lattice/mantle40/decode.py
@@ -18,7 +18,7 @@ def Decode(i, n, invert=False, **kwargs):
     @return: 1 if the n-bit input equals i
     """
 
-    assert n <= 8
+    #assert n <= 8
 
     if n <= 4:
         i = 1 << i

--- a/mantle/lattice/mantle40/decode.py
+++ b/mantle/lattice/mantle40/decode.py
@@ -18,8 +18,6 @@ def Decode(i, n, invert=False, **kwargs):
     @return: 1 if the n-bit input equals i
     """
 
-    #assert n <= 8
-
     if n <= 4:
         i = 1 << i
         if invert:


### PR DESCRIPTION
Not sure why this assert statement was here. Tested for n = 10 by creating a CounterModM(1000, 10) (which uses Decode) and verifying that COUTs are produced every 1000 clocks.