### PR TITLE
Add dynamic __getitem__ which generates a Mux

### DIFF
--- a/mantle/common/operator.py
+++ b/mantle/common/operator.py
@@ -246,3 +246,19 @@ def mux(I, S):
     elif S.const():
         return I[seq2int(S.bits())]
     return Mux(len(I), get_length(I[0]))(*I, S)
+
+
+orig_get_item = m.ArrayType.__getitem__
+
+
+def dynamic_mux_select(self, S):
+    if isinstance(S, m.Type):
+        if isinstance(self.T, m._BitKind):
+            length = None
+        else:
+            length = len(self.T)
+        return Mux(len(self), length)(m.bits(self.ts), S)
+    return orig_get_item(self, S)
+
+
+setattr(m.ArrayType, "__getitem__", dynamic_mux_select)

--- a/tests/test_coreir/gold/test_dynamic_mux_getitem.json
+++ b/tests/test_coreir/gold/test_dynamic_mux_getitem.json
@@ -1,0 +1,43 @@
+{"top":"global.TestDynamicMuxGetItem",
+"namespaces":{
+  "global":{
+    "modules":{
+      "TestDynamicMuxGetItem":{
+        "type":["Record",[
+          ["I",["Array",2,"BitIn"]],
+          ["S","BitIn"],
+          ["O","Bit"]
+        ]],
+        "instances":{
+          "inst0":{
+            "modref":"global._Mux2"
+          }
+        },
+        "connections":[
+          ["self.I","inst0.I"],
+          ["self.O","inst0.O"],
+          ["self.S","inst0.S"]
+        ]
+      },
+      "_Mux2":{
+        "type":["Record",[
+          ["I",["Array",2,"BitIn"]],
+          ["S","BitIn"],
+          ["O","Bit"]
+        ]],
+        "instances":{
+          "inst0":{
+            "modref":"corebit.mux"
+          }
+        },
+        "connections":[
+          ["self.I.0","inst0.in0"],
+          ["self.I.1","inst0.in1"],
+          ["self.O","inst0.out"],
+          ["self.S","inst0.sel"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_coreir/test_operator.py
+++ b/tests/test_coreir/test_operator.py
@@ -143,3 +143,16 @@ def test_binary_op(op, N, T, TType):
     m.compile(f'build/{_name}', TestCircuit)
     assert check_files_equal(__file__, f"build/{_name}.v",
                              f"gold/{_name}.v")
+
+
+def test_dyanmic_mux_getitem():
+    class TestDynamicMuxGetItem(m.Circuit):
+        IO = ["I", m.In(m.Bits(2)), "S", m.In(m.Bit), "O", m.Out(m.Bit)]
+
+        @classmethod
+        def definition(io):
+            m.wire(io.O, io.I[io.S])
+    m.compile("build/test_dynamic_mux_getitem", TestDynamicMuxGetItem,
+              output="coreir")
+    assert check_files_equal(__file__, f"build/test_dynamic_mux_getitem.json",
+                             f"gold/test_dynamic_mux_getitem.json")


### PR DESCRIPTION
Overloads the `__getitem__` operator of `ArrayType` to enable this syntax:
```
    class TestDynamicMuxGetItem(m.Circuit):
        IO = ["I", m.In(m.Bits(2)), "S", m.In(m.Bit), "O", m.Out(m.Bit)]
         @classmethod
        def definition(io):
            m.wire(io.O, io.I[io.S])
```

The new `__getitem__` checks if the select is a magma value (instance of `m.Type`), if so, generates a Mux, otherwise calls the original `__getitem__` (so you can still statically select bits using integer indices or slices).