### PR TITLE
Add division operator for coreir

### DIFF
--- a/mantle/common/arith.py
+++ b/mantle/common/arith.py
@@ -1,5 +1,5 @@
 import magma as m
-from mantle import DefineAdd, DefineSub, DefineNegate, DefineUDiv, DefineSDiv
+from mantle import DefineAdd, DefineSub, DefineNegate
 
 __all__ = [ "Add", "Sub", "Negate", "UDiv", "SDiv" ]
 
@@ -20,6 +20,9 @@ def UDiv(width, **kwargs):
     if m.mantle_target != "coreir":
         raise NotImplementedError(
             "Division not implemented for mantle target {m.mantle_target}")
+    # Workaround import error for other targets by delaying import until after
+    # if guard
+    from mantle import DefineUDiv
     return DefineUDiv(width)(**kwargs)
 
 
@@ -27,4 +30,7 @@ def SDiv(width, **kwargs):
     if m.mantle_target != "coreir":
         raise NotImplementedError(
             "Division not implemented for mantle target {m.mantle_target}")
+    # Workaround import error for other targets by delaying import until after
+    # if guard
+    from mantle import DefineSDiv
     return DefineSDiv(width)(**kwargs)

--- a/mantle/common/arith.py
+++ b/mantle/common/arith.py
@@ -1,6 +1,7 @@
-from mantle import DefineAdd, DefineSub, DefineNegate
+import magma as m
+from mantle import DefineAdd, DefineSub, DefineNegate, DefineUDiv, DefineSDiv
 
-__all__ = [ "Add", "Sub", "Negate" ]
+__all__ = [ "Add", "Sub", "Negate", "UDiv", "SDiv" ]
 
 
 def Add(n, cin=False, cout=False, **kwargs):
@@ -14,3 +15,16 @@ def Sub(n, cin=False, cout=False, **kwargs):
 def Negate(width, **kwargs):
     return DefineNegate(width)(**kwargs)
 
+
+def UDiv(width, **kwargs):
+    if m.mantle_target != "coreir":
+        raise NotImplementedError(
+            "Division not implemented for mantle target {m.mantle_target}")
+    return DefineUDiv(width)(**kwargs)
+
+
+def SDiv(width, **kwargs):
+    if m.mantle_target != "coreir":
+        raise NotImplementedError(
+            "Division not implemented for mantle target {m.mantle_target}")
+    return DefineSDiv(width)(**kwargs)

--- a/mantle/common/operator.py
+++ b/mantle/common/operator.py
@@ -2,7 +2,7 @@ from functools import wraps
 
 import magma as m
 from magma.bitutils import seq2int
-from mantle import And, NAnd, Or, NOr, XOr, NXOr, LSL, LSR, Not, Invert
+from mantle import And, NAnd, Or, NOr, XOr, NXOr, LSL, LSR, Not, Invert, UDiv, SDiv
 from mantle import ASR
 from mantle import EQ, NE, ULT, ULE, UGT, UGE, SLT, SLE, SGT, SGE
 from mantle import Mux
@@ -81,7 +81,8 @@ for _operator_name, _Circuit in (
     ("sub", Sub),
     # TODO: These lack implementations
     # ("mul", Mul),
-    # ("div", Div)
+    ("udiv", UDiv),
+    ("sdiv", SDiv)
 ):
     __all__ += [_operator_name]
 
@@ -93,7 +94,7 @@ for _operator_name, _Circuit in (
     @check_operator_args
     @_pass_closure_vars_as_args(_Circuit, _operator_name)
     def operator(circuit, name, width, *args, **kwargs):
-        if name in ["add", "sub"]:
+        if name in ["add", "sub", "mul", "udiv", "sdiv"]:
             # These don't have a height
             if len(args) > 2:
                 raise Exception(f"{name} operator expects 2 arguments")
@@ -170,7 +171,6 @@ arithmetic_ops = [
     ("__add__", add),
     ("__sub__", sub),
     # ("__mul__", mul),
-    # ("__div__", div)
 ]
 
 
@@ -232,6 +232,9 @@ relational_ops = [
 for method, op in arithmetic_ops + relational_ops:
     setattr(m.SIntType, method, op)
     setattr(m.UIntType, method, op)
+
+m.SIntType.__truediv__ = sdiv
+m.UIntType.__truediv__ = udiv
 
 for type_ in (m._BitType, m.ArrayType):
     setattr(type_, "__eq__", eq)

--- a/mantle/coreir/__init__.py
+++ b/mantle/coreir/__init__.py
@@ -17,7 +17,8 @@ from .logic import (
 
 #from .fulladder import FullAdder
 #from .halfadder import HalfAdder
-from .arith import DefineAdd, DefineSub, DefineNegate, DefineASR, ASR, DefineCoreirAdd, DefineCoreirMul
+from .arith import DefineAdd, DefineSub, DefineNegate, DefineASR, ASR, \
+    DefineCoreirAdd, DefineCoreirMul, DefineUDiv, DefineSDiv
 
 from .FF import FF, DFF, DefineDFF, DefineCoreirReg
 from .LUT import LUT

--- a/mantle/coreir/arith.py
+++ b/mantle/coreir/arith.py
@@ -161,3 +161,12 @@ def DefineASR(width):
 def ASR(width, **kwargs):
     return DefineASR(width)(**kwargs)
 
+
+DefineCoreirUDiv = declare_binop("udiv", operator.truediv)
+
+DefineUDiv = DefineCoreirUDiv
+
+
+DefineCoreirSDiv = declare_binop("sdiv", operator.truediv)
+
+DefineSDiv = DefineCoreirSDiv

--- a/tests/test_coreir/gold/TestsCircuit_sdiv_4_SInt_SIntType.json
+++ b/tests/test_coreir/gold/TestsCircuit_sdiv_4_SInt_SIntType.json
@@ -1,0 +1,34 @@
+{"top":"global.TestsCircuit_sdiv_4_SInt_SIntType",
+"namespaces":{
+  "global":{
+    "modules":{
+      "TestsCircuit_sdiv_4_SInt_SIntType":{
+        "type":["Record",[
+          ["I0",["Array",4,"BitIn"]],
+          ["I1",["Array",4,"BitIn"]],
+          ["O0",["Array",4,"Bit"]],
+          ["O1",["Array",4,"Bit"]]
+        ]],
+        "instances":{
+          "inst0":{
+            "genref":"coreir.sdiv",
+            "genargs":{"width":["Int",4]}
+          },
+          "inst1":{
+            "genref":"coreir.sdiv",
+            "genargs":{"width":["Int",4]}
+          }
+        },
+        "connections":[
+          ["self.I0","inst0.in0"],
+          ["self.I1","inst0.in1"],
+          ["self.O0","inst0.out"],
+          ["self.I0","inst1.in0"],
+          ["self.I1","inst1.in1"],
+          ["self.O1","inst1.out"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_coreir/gold/TestsCircuit_udiv_4_UInt_UIntType.json
+++ b/tests/test_coreir/gold/TestsCircuit_udiv_4_UInt_UIntType.json
@@ -1,0 +1,34 @@
+{"top":"global.TestsCircuit_udiv_4_UInt_UIntType",
+"namespaces":{
+  "global":{
+    "modules":{
+      "TestsCircuit_udiv_4_UInt_UIntType":{
+        "type":["Record",[
+          ["I0",["Array",4,"BitIn"]],
+          ["I1",["Array",4,"BitIn"]],
+          ["O0",["Array",4,"Bit"]],
+          ["O1",["Array",4,"Bit"]]
+        ]],
+        "instances":{
+          "inst0":{
+            "genref":"coreir.udiv",
+            "genargs":{"width":["Int",4]}
+          },
+          "inst1":{
+            "genref":"coreir.udiv",
+            "genargs":{"width":["Int",4]}
+          }
+        },
+        "connections":[
+          ["self.I0","inst0.in0"],
+          ["self.I1","inst0.in1"],
+          ["self.O0","inst0.out"],
+          ["self.I0","inst1.in0"],
+          ["self.I1","inst1.in1"],
+          ["self.O1","inst1.out"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_coreir/gold/test_sdiv.json
+++ b/tests/test_coreir/gold/test_sdiv.json
@@ -1,0 +1,26 @@
+{"top":"global.coreir_sdiv4_wrapped",
+"namespaces":{
+  "global":{
+    "modules":{
+      "coreir_sdiv4_wrapped":{
+        "type":["Record",[
+          ["I0",["Array",4,"BitIn"]],
+          ["I1",["Array",4,"BitIn"]],
+          ["O",["Array",4,"Bit"]]
+        ]],
+        "instances":{
+          "inst0":{
+            "genref":"coreir.sdiv",
+            "genargs":{"width":["Int",4]}
+          }
+        },
+        "connections":[
+          ["self.I0","inst0.in0"],
+          ["self.I1","inst0.in1"],
+          ["self.O","inst0.out"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_coreir/gold/test_udiv.json
+++ b/tests/test_coreir/gold/test_udiv.json
@@ -1,0 +1,26 @@
+{"top":"global.coreir_udiv4_wrapped",
+"namespaces":{
+  "global":{
+    "modules":{
+      "coreir_udiv4_wrapped":{
+        "type":["Record",[
+          ["I0",["Array",4,"BitIn"]],
+          ["I1",["Array",4,"BitIn"]],
+          ["O",["Array",4,"Bit"]]
+        ]],
+        "instances":{
+          "inst0":{
+            "genref":"coreir.udiv",
+            "genargs":{"width":["Int",4]}
+          }
+        },
+        "connections":[
+          ["self.I0","inst0.in0"],
+          ["self.I1","inst0.in1"],
+          ["self.O","inst0.out"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_coreir/test_arith.py
+++ b/tests/test_coreir/test_arith.py
@@ -1,7 +1,7 @@
 import magma as m
 from magma import *
 from magma.testing import check_files_equal
-from mantle.coreir.arith import DefineAdd, DefineSub, DefineNegate, DefineASR
+from mantle.coreir.arith import DefineAdd, DefineSub, DefineNegate, DefineASR, DefineUDiv, DefineSDiv
 from fault.test_vectors import generate_function_test_vectors, generate_simulator_test_vectors
 from magma.simulator.coreir_simulator import CoreIRSimulator
 from .util import wrap
@@ -60,3 +60,15 @@ def test_asr():
     compile("build/test_asr", DefineASR(4), output="coreir")
     assert check_files_equal(__file__,
             "build/test_asr.json", "gold/test_asr.json")
+
+
+def test_udiv():
+    compile("build/test_udiv", wrap(DefineUDiv(4)), output="coreir")
+    assert check_files_equal(__file__,
+            "build/test_udiv.json", "gold/test_udiv.json")
+
+
+def test_sdiv():
+    compile("build/test_sdiv", wrap(DefineSDiv(4)), output="coreir")
+    assert check_files_equal(__file__,
+            "build/test_sdiv.json", "gold/test_sdiv.json")

--- a/tests/test_coreir/test_operator.py
+++ b/tests/test_coreir/test_operator.py
@@ -87,7 +87,8 @@ def test_unary_op(op, N, T, TType):
     op(name="sub", operator="-"),
     # TODO: Enable these once we have implementations
     # op(name="mul", operator="*"),
-    # op(name="div", operator="/"),
+    op(name="udiv", operator="/"),
+    op(name="sdiv", operator="/"),
     op(name="eq", operator="=="),
     op(name="ne", operator="!="),
     op(name="lt", operator="<"),
@@ -104,6 +105,11 @@ def test_binary_op(op, N, T, TType):
     Tests mantle.operator by using the operator.{op.name} method directly and
     using the overloaded {op.operator} if it is not None.
     """
+
+    if op.name == "udiv" and T != m.UInt:
+        pytest.skip("udiv only defined for m.UInt")
+    elif op.name == "sdiv" and T != m.SInt:
+        pytest.skip("sdiv only defined for m.SInt")
     def to_str(x):
         if callable(x):
             return x.__name__


### PR DESCRIPTION
I don't believe division has been implemented for other mantle targets, so this shouldn't introduce any interface mismatch issues.

I've defined `UDiv` and `SDiv`, since coreir provides two separate primitives for the operations depending on the signedness.

For operators, `UInt` has `/` mapped to `UDiv` and `SInt` has `/` mapped to `SDiv`.