### PR TITLE
Initial pass at documenting primitives

### DIFF
--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -101,4 +101,4 @@ Issues:
 * coreir has custom RAM implementation, should it just use the common.RAM?
 
 Generators:
-* `Memory(height, width, rom, readonly)` - **TODO: coreir does not have rom parameter and does not support ROMs, also missing define+instance variant**
+* `Memory(height, width, rom, readonly)` - **TODO: mantle.coreir does not have rom parameter and does not support ROMs. I think this is an old artifact of coreir lacking support for ROMs, which it should now support. also missing define+instance variant**

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -1,0 +1,104 @@
+# Mantle Primitives
+The mantle primitives define a set of generator interfaces that each mantle
+target must implement.  They are designed to be equivalent to the coreir
+primitives.
+
+## Arithmetic (arith)
+
+Issues:
+* Parameter names are not consistent (e.g. `n` vs `width`)
+* `cin, cout` parameters
+
+Generators:
+* `Add(n, cin, cout)` - **TODO: Different than coreir.add, which doesn't have cin or cout**
+* `Sub(n, cin, cout)` - **TODO: Same issue as add**
+* `Negate(width)`
+* `ASR(width)` - **TODO: Missing in mantle**
+* `Mul(width)` - **TODO: Missing in mantle**
+* `UDiv(width)` - **TODO: Missing in mantle**
+* `SDiv(width)` - **TODO: Missing in mantle**
+* `UMod(width)` - **TODO: Missing in mantle**
+* `SMod(width)` - **TODO: Missing in mantle**
+
+## Logic
+
+Issues:
+* mantle uses a `height` parameter whereas coreir generators are binary
+* `mantle40` uses `n` for `DefineReduce{Op}` parameter but `height` for
+  `Reduce{Op}`
+
+Generators:
+* `And(height, width)`
+* `ReduceAnd(height, width)`
+* `NAnd(height, width)`
+* `ReduceNAnd(height)`
+* `Not` - 1-bit invert
+* `Or(height, width)`
+* `ReduceOr(height)`
+* `NOr(height, width)`
+* `ReduceNOr(height)`
+* `XOr(height, width)`
+* `ReduceXOr(height)`
+* `NXOr(height, width)`
+* `ReduceNXOr(height)`
+* `Invert(width)` - **TODO: mantle40 uses `n` parameter for `Invert`**
+* `LSL(width, shift_amount)`
+* `LSR(width, shift_amount)`
+* `StaticLeftShift(width)` - **TODO: Should these primitives? Issue is that if we instantiate an LSL, we don't know if the shift input is constant or dynamic. We could have a pass that inspects all LSL/LSR instances and changes those with static shift amounts to only use wiring. Then we could just have LSL and LSR**
+* `StaticRightShift(width)`
+
+## Compare
+
+Issues:
+* Define+Instance variants of comparisons (e.g. `ULT(n)`) missing from
+  `mantle40`, they only have `Define{op}` variants
+
+Generators:
+* `EQ(n)`
+* `NE(n)`
+* `ULT(n)`
+* `ULE(n)`
+* `UGT(n)`
+* `UGE(n)`
+* `SLT(n)`
+* `SLE(n)`
+* `SGT(n)`
+* `SGE(n)`
+
+## Mux
+
+Issues:
+
+Generators:
+* `Mux(height, width)` - **TODO: mantle40 limited to heights `[2, 4, 8, 16]`**
+
+## Flip Flops (FF)
+
+Issues:
+* mantle has many more parameters not available in coreir, we could move to
+  having a basic FF primitive, then have these higher level features built on
+  top of them
+
+Generators:
+* `DFF(init, has_ce, has_reset, edge, sync)`
+* `SRFF(init, has_ce, has_reset, edge, sync)` - **TODO: Missing from corier**
+* `RSFF(init, has_ce, has_reset, edge, sync)` - **TODO: Missing from corier**
+* `JKFF(init, has_ce, has_reset, edge, sync)` - **TODO: Missing from corier**
+* `TFF(init, has_ce, has_reset, edge, sync)` - **TODO: Missing from corier**
+
+## LUT
+Issues:
+* coreir uses `init` parameter instead of `rom` (used by mantle40) and `N`
+  instead of `n`
+
+Generators:
+* `LUT(rom, n)` - `rom` is the initialization value, `n` is the number of bits
+  (optional, can be inferred from `rom`)
+
+## Memory
+
+Issues:
+* coreir has custom RAM implementation, should it just use the common.RAM?
+
+Generators:
+* `Memory(height, width, rom, readonly)` - **TODO: coreir does not have rom parameter and does not support ROMs, also missing define+instance variant**


### PR DESCRIPTION
@phanrahan @rdaly525 here is the initial pass at documenting the mantle primitives.

I started with documenting the interface to the generators, organized by modules. In mantle we have
* arith
* logic
* compare
* mux
* FF
* LUT
* Memory

The major issues I found are:
* Inconsistent parameter names across mantle implementations (e.g. `n` vs `width`)
* `cin, cout` parameters in mantle versus coreir add/sub primitives (no cin/cout)
* `height, width` parameters in mantle logic primitives versus coreir logic primitives which are binary
* Some missing Define+Instance variants in mantle40 (e.g. `DefineUGT` but no `UGT`). The fix for this is simple, once we have consistent interfaces across implementations, they should be able to reuse the same Define+Instance variants.
* FF primitives have way more parameters than coreir (`has_ce, has_reset, ...`).

It seems like most of the consistency issues between mantle primitives and coreir primitives can be resolved by defining simpler mantle primitives (e.g. a basic FF that matches the coreir primitive, a basic add/sub that matches the coreir primitives). Then, the richer generator interfaces can be implemented in terms of these primitives. 

I'm not sure what's the best way to organize this. For example, we could have `Add` match the coreir primitive interface, and then define an `AddC` which extends it with carry logic. Similarly for flipflops.

A complex issue is the logic primitives, which currently define height and width parameters. We could define a binary `Or` to match coreir, but how do we name a more general `Or`? We could invert the solution, and have explicit primitive circuits, e.g. `OrPrim`, then preserve the current semantics of `Or`. A final option is to have coreir introduce a height parameter.

@rdaly525 can you review the list of generators and see if there's anything missing in mantle that coreir supports?

@phanrahan can you review the list of generators and see if there's anything that is missing orshould be in common. Also, what do you think about the proposed resolution of defining the basic primitives that match coreir, and building the higher level constructs out of the primitives? Seems like a clean design. Major issue here is how to design/organize the logic primitives with the `height` and `width` parameters (reconciling them with the binary coreir primitives).