### PR TITLE
Workaround fix for phanrahan/magma/issues/333

### DIFF
--- a/mantle/lattice/mantle40/compare.py
+++ b/mantle/lattice/mantle40/compare.py
@@ -168,7 +168,7 @@ def DefineSCMP(opname, op, reverse, n):
         IO = ['I0', In(T), 'I1', In(T), "O", Out(Bit)]
         @classmethod
         def definition(io):
-            sub = DefineSub(n)()
+            sub = DefineSub(n, cin=False, cout=False)()
             cmp = LUT3(op)
             if not reverse:
                 wire(cmp( sub(io.I0, io.I1)[-1], io.I0[-1], io.I1[-1] ), io.O)


### PR DESCRIPTION
Make DefineSCMP's DefineSub method call the same as https://github.com/phanrahan/mantle/blob/cf6c792a0dab0e6ba0245b04904bed8c36a0bdb1/mantle/common/arith.py#L10-L11 to allow lru_cache to cache the method correctly. Because lru_cache doesn't consolidate `cin=False, cout=False, DefineSub(n, cin=cin, cout=cout)` and `DefineSub(n)` even though the default cin and cout values are the same.

https://stackoverflow.com/q/37517607/629118