### PR TITLE
Improve names for coreir primitives

### DIFF
--- a/mantle/common/operator.py
+++ b/mantle/common/operator.py
@@ -278,12 +278,12 @@ for type_ in (m._BitType, m.ArrayType):
 
 @export
 @preserve_type
-def mux(I, S):
+def mux(I, S, **kwargs):
     if isinstance(S, int):
         return I[S]
     elif S.const():
         return I[seq2int(S.bits())]
-    return Mux(len(I), T=type(I[0]))(*I, S)
+    return Mux(len(I), T=type(I[0]), **kwargs)(*I, S)
 
 
 orig_get_item = m.ArrayType.__getitem__

--- a/mantle/coreir/FF.py
+++ b/mantle/coreir/FF.py
@@ -90,7 +90,7 @@ def DefineCoreirReg(width, init=0, has_reset=False, T=Bits):
         coreir_genargs=gen_args,
         coreir_configargs=config_args,
         coreir_name="reg_arst" if has_reset else "reg",
-        verilog_name="coreir_" + name,
+        verilog_name="coreir_" + ("reg_arst" if has_reset else "reg"),
         coreir_lib="coreir"
     )
 

--- a/mantle/coreir/MUX.py
+++ b/mantle/coreir/MUX.py
@@ -66,7 +66,7 @@ def DefineMux(height=2, width=None, T=None):
         assert width is None, "Can only specify width **or** T"
         # Sanitize names for verilog by removing parens
         # TODO: Make this a reuseable feature
-        suffix = str(T).replace("(", "$").replace(")", "$").replace(",", "$")
+        suffix = str(T).replace("(", "").replace(")", "").replace(",", "_")
         T = T
     else:
         suffix = f"{width}"

--- a/mantle/coreir/register.py
+++ b/mantle/coreir/register.py
@@ -12,9 +12,9 @@ def DefineRegister(n, init=0, has_ce=False, has_reset=False,
 
     if has_reset or has_ce:
         class Register(m.Circuit):
-            name = f"Register__has_ce_{has_ce}__has_reset_{has_reset}__" \
-                   f"has_async_reset__{has_async_reset}__" \
-                   f"type_{_type.__name__}__n_{n}"
+            name = f"Register_has_ce_{has_ce}_has_reset_{has_reset}_" \
+                   f"has_async_reset_{has_async_reset}_" \
+                   f"type_{_type.__name__}_n_{n}"
             IO = ["I", m.In(T), "O", m.Out(T)]
             IO += m.ClockInterface(has_ce=has_ce,
                                    has_reset=has_reset,
@@ -22,12 +22,12 @@ def DefineRegister(n, init=0, has_ce=False, has_reset=False,
 
             @classmethod
             def definition(io):
-                reg = DefineCoreirReg(n, init, has_async_reset, _type)()
+                reg = DefineCoreirReg(n, init, has_async_reset, _type)(name="value")
                 I = io.I
                 if has_reset:
                     I = mantle.mux([io.I, m.bits(init, n)], io.RESET)
                 if has_ce:
-                    I = mantle.mux([reg.O, I], io.CE)
+                    I = mantle.mux([reg.O, I], io.CE, name="enable_mux")
                 m.wire(I, reg.I)
                 m.wire(io.O, reg.O)
         return Register


### PR DESCRIPTION
This just improves the instance names used for various coreir implementations.