### PR TITLE
Converted Decode To Equality in Counter

### DIFF
--- a/mantle/common/countermod.py
+++ b/mantle/common/countermod.py
@@ -27,7 +27,7 @@ def DefineCounterModM(m, n, cin=False, cout=True, incr=1,
 
     counter = Counter(n, cin=cin, cout=False, incr=incr, 
                    has_ce=has_ce, has_reset=True)
-    reset = Decode(m - 1, n)(counter.O)
+    reset = (m-1) == counter.O
 
     if has_reset:
         reset = Or(2)(reset, CounterModM.RESET)


### PR DESCRIPTION
The LUT is currently not synthesizable from CoreIR to Verilog. Decode requires a LUT in Mantle. The equality does not. Thus, the counters are now synthesizable from CoreIR to Verilog.

While one might argue that the answer is to add LUTs to CoreIR rather than change the counters, this is a much faster solution. Speed is important since I'm trying to hit the publication deadline in 2 weeks. Also, == and decode are equally good instructions.