### PR TITLE
Support for lassen bfloat ops

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
 # End install conda
 
 - git clone https://github.com/phanrahan/magma.git
+- git -C magma checkout lassen-bfloat
 - if [[ $TRAVIS_BRANCH == 'coreir-dev' ]]; then git -C magma checkout coreir-dev; fi
 - pip install -r magma/requirements.txt
 - pip install -e magma

--- a/mantle/common/arith.py
+++ b/mantle/common/arith.py
@@ -4,26 +4,26 @@ from mantle import DefineAdd, DefineSub, DefineNegate
 __all__ = [ "Add", "Sub", "Negate", "UDiv", "SDiv", "UMod", "SMod", "Mul"]
 
 
-def Add(n, cin=False, cout=False, **kwargs):
-    return DefineAdd(n, cin=cin, cout=cout)(**kwargs)
+def Add(n, cin=False, cout=False, T=m.Bits, **kwargs):
+    return DefineAdd(n, cin=cin, cout=cout, T=T)(**kwargs)
 
 
-def Sub(n, cin=False, cout=False, **kwargs):
-    return DefineSub(n, cin=cin, cout=cout)(**kwargs)
+def Sub(n, cin=False, cout=False, T=m.Bits, **kwargs):
+    return DefineSub(n, cin=cin, cout=cout, T=T)(**kwargs)
 
 
 def Negate(width, **kwargs):
     return DefineNegate(width)(**kwargs)
 
 
-def Mul(width, **kwargs):
+def Mul(width, T=m.Bits, **kwargs):
     if m.mantle_target != "coreir":
         raise NotImplementedError(
             "Mul not implemented for mantle target {m.mantle_target}")
     # Workaround import error for other targets by delaying import until after
     # if guard
     from mantle import DefineMul
-    return DefineMul(width)(**kwargs)
+    return DefineMul(width, T=T)(**kwargs)
 
 
 def UDiv(width, **kwargs):

--- a/mantle/common/operator.py
+++ b/mantle/common/operator.py
@@ -128,7 +128,7 @@ for _operator_name, _Circuit in (
                 # These don't have a height
                 if len(args) > 2:
                     raise Exception(f"{name} operator expects 2 arguments")
-                return circuit(width, **kwargs)(*args)
+                return circuit(width, T=type(args[0]), **kwargs)(*args)
             else:
                 return circuit(len(args), width, **kwargs)(*args)
     operator.__name__ = _operator_name
@@ -307,6 +307,7 @@ relational_ops = [
 for method, op in arithmetic_ops + relational_ops:
     setattr(m.SIntType, method, op)
     setattr(m.UIntType, method, op)
+    setattr(m.BFloat, method, op)
 
 m.SIntType.__truediv__ = sdiv
 m.UIntType.__truediv__ = udiv

--- a/mantle/primitives/arith.py
+++ b/mantle/primitives/arith.py
@@ -1,4 +1,5 @@
 from magma import *
+import magma as m
 
 
 @circuit_generator
@@ -46,10 +47,10 @@ def add(*args, **kwargs):
 
 
 @circuit_generator
-def DeclareSub(N, cin=False, cout=False):
+def DeclareSub(N, cin=False, cout=False, T=m.Bits):
     has_cin = cin
     has_cout = cout
-    T = Bits[N]
+    T = T[N]
     IO_ = ['I0', In(T), 'I1', In(T), 'O', Out(T)]
     name_ = "Sub{}".format(N)
     if has_cout:

--- a/tests/test_coreir/test_const.py
+++ b/tests/test_coreir/test_const.py
@@ -7,7 +7,7 @@ from .util import wrap
 def test_const():
     Const8 = DefineCoreirConst(width=4, value=8)
     assert repr(Const8) == """\
-coreir_const48 = DeclareCircuit("coreir_const48", "O", Out(Bits(4)))"""
+coreir_const48 = DeclareCircuit("coreir_const48", "O", Out(Bits[4]))"""
     compile("build/test_const", wrap(Const8), output="coreir")
     assert check_files_equal(__file__,
             "build/test_const.json", "gold/test_const.json")


### PR DESCRIPTION
Augments the add/mul ops to dispatch on the type.  Before they assumed they were bits using the standard coreir primtiives, now it will generate `float.add` and `float.mul` for the bfloat type.