### PR TITLE
Remove n <= 8 Decode Assertion

### DIFF
--- a/mantle/common/decode.py
+++ b/mantle/common/decode.py
@@ -18,8 +18,6 @@ def Decode(i, n, invert=False, **kwargs):
     @return: 1 if the n-bit input equals i
     """
 
-    assert n <= 8
-
     if n <= 4:
         i = 1 << i
         if invert:


### PR DESCRIPTION
Fixing the same issue as https://github.com/phanrahan/mantle/pull/132 but with different approach. 

LUTs are now supported in CoreIR (https://github.com/rdaly525/coreir/pull/690)

n <= 8 restriction still is only remaining problem. I'm removing that restriction as suggested by @leonardt https://github.com/phanrahan/mantle/pull/132#pullrequestreview-206576191
