### PR TITLE
Changing CoreIR Operators To Use Singleton CoreIR Context

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -35,5 +35,5 @@ def mantle_test():
     from magma import clear_cachedFunctions
     clear_cachedFunctions()
 
-    magma.backend.coreir_.__reset_context()
+    magma.backend.coreir_.CoreIRContextSingleton().reset_instance()
 

--- a/mantle/common/countermod.py
+++ b/mantle/common/countermod.py
@@ -62,7 +62,7 @@ def CounterModM(m, n, cin=False, cout=True, incr=1,
     return DefineCounterModM(m, n, cin, cout, incr, has_ce, has_reset=has_reset)(**kwargs)
 
 def SizedCounterModM(m, cin=False, cout=False, incr=1, 
-    has_ce=False, **kwargs):
+    has_ce=False, has_reset=False, **kwargs):
     """
     This is that counts from 0 to m - 1 that uses the minimum number of bits
     :param m: The value the counter counts up to
@@ -73,7 +73,7 @@ def SizedCounterModM(m, cin=False, cout=False, incr=1,
     :param kwargs: Args passed to the counter circuit when it is being initialized
     :return: A counter circuit
     """
-    return DefineCounterModM(m, math.ceil(math.log(m, 2)), cin, cout, incr, has_ce)(**kwargs)
+    return DefineCounterModM(m, math.ceil(math.log(m, 2)), cin, cout, incr, has_ce, has_reset)(**kwargs)
 
 DefineUpCounterModM = DefineCounterModM
 UpCounterModM = CounterModM

--- a/mantle/coreir/MUX.py
+++ b/mantle/coreir/MUX.py
@@ -4,7 +4,7 @@ from __future__ import division
 from magma import *
 import magma as m
 from magma.backend.coreir_ import CoreIRBackend
-from magma.frontend.coreir_ import DefineCircuitFromGeneratorWrapper
+from magma.frontend.coreir_ import DefineCircuitFromGeneratorWrapper, GetCoreIRBackend
 from .util import DeclareCoreirCircuit
 from hwtypes import BitVector
 
@@ -129,7 +129,8 @@ Mux4 = DefineMux(4)
 Mux8 = DefineMux(8)
 Mux16 = DefineMux(16)
 
-def DefineCommonlibMuxN(cirb: CoreIRBackend, N: int, width: int):
+@cache_definition
+def DefineCommonlibMuxN(N: int, width: int):
     """
     Get a Mux that handles any number of inputs
 
@@ -144,9 +145,9 @@ def DefineCommonlibMuxN(cirb: CoreIRBackend, N: int, width: int):
     Note: even though this isn't a RAM, the AddrWidth computation is the same.
     """
     name = "CommonlibMuxN_n{}_w{}".format(str(N), str(width))
-    return DefineCircuitFromGeneratorWrapper(cirb, "commonlib", "muxn",
+    return DefineCircuitFromGeneratorWrapper(GetCoreIRBackend(), "commonlib", "muxn",
                                              name, ["mantle", "coreir", "global"],
                                              {"N": N, "width": width})
 
-def CommonlibMuxN(cirb: CoreIRBackend, N: int, width: int):
-    return DefineCommonlibMuxN(cirb, N, width)()
+def CommonlibMuxN(N: int, width: int):
+    return DefineCommonlibMuxN(N, width)()

--- a/mantle/coreir/memory.py
+++ b/mantle/coreir/memory.py
@@ -1,6 +1,6 @@
 from magma import *
 from hwtypes import BitVector
-from magma.frontend.coreir_ import CircuitInstanceFromGeneratorWrapper
+from magma.frontend.coreir_ import CircuitInstanceFromGeneratorWrapper, GetCoreIRBackend
 from .register import register
 
 
@@ -47,8 +47,8 @@ def DefineCoreirMem(depth, width):
             coreir_genargs={"width": width, "depth": depth})
             # coreir_configargs={"init": "0"})
 
-def CoreirMem(cirb, depth, width):
-    return CircuitInstanceFromGeneratorWrapper(cirb, "coreir", "mem", "CoreIRmem_w{}_d{}".format(width, depth),
+def CoreirMem(depth, width):
+    return CircuitInstanceFromGeneratorWrapper(GetCoreIRBackend(), "coreir", "mem", "CoreIRmem_w{}_d{}".format(width, depth),
                                                ["global"], {"width": width, "depth": depth})
 
 def DefineROM(height, width,read_latency=0):

--- a/mantle/coreir/type_helpers.py
+++ b/mantle/coreir/type_helpers.py
@@ -1,14 +1,25 @@
-from magma.frontend.coreir_ import CircuitInstanceFromGeneratorWrapper, GetCoreIRBackend
+from magma.frontend.coreir_ import DefineCircuitFromGeneratorWrapper, GetCoreIRBackend
 from magma import cache_definition
 
 @cache_definition
-def Term(width: int):
+def DefineTerm(width: int):
     """
     Take in an array of wires and connect it to nothing so that you don't get an unconnected
+    Returns a circuit definition.
 
     :param cirb: The CoreIR backend currently be used
     :param width: The width of the element to absorb
     :return:
     """
-    return CircuitInstanceFromGeneratorWrapper(GetCoreIRBackend(), "coreir", "term", "term_w" + str(width), ["global"],
+    return DefineCircuitFromGeneratorWrapper(GetCoreIRBackend(), "coreir", "term", "term_w" + str(width), ["global"],
                                                {"width": width})
+def Term(width: int):
+    """
+    Take in an array of wires and connect it to nothing so that you don't get an unconnected
+    Returns an instance of a circuit definition.
+
+    :param cirb: The CoreIR backend currently be used
+    :param width: The width of the element to absorb
+    :return:
+    """
+    return DefineTerm(width)()

--- a/mantle/coreir/type_helpers.py
+++ b/mantle/coreir/type_helpers.py
@@ -1,7 +1,8 @@
-from magma.backend.coreir_ import CoreIRBackend
-from magma.frontend.coreir_ import CircuitInstanceFromGeneratorWrapper
+from magma.frontend.coreir_ import CircuitInstanceFromGeneratorWrapper, GetCoreIRBackend
+from magma import cache_definition
 
-def Term(cirb: CoreIRBackend, width: int):
+@cache_definition
+def Term(width: int):
     """
     Take in an array of wires and connect it to nothing so that you don't get an unconnected
 
@@ -9,5 +10,5 @@ def Term(cirb: CoreIRBackend, width: int):
     :param width: The width of the element to absorb
     :return:
     """
-    return CircuitInstanceFromGeneratorWrapper(cirb, "coreir", "term", "term_w" + str(width), ["global"],
+    return CircuitInstanceFromGeneratorWrapper(GetCoreIRBackend(), "coreir", "term", "term_w" + str(width), ["global"],
                                                {"width": width})

--- a/tests/test_coreir/test_coreir_mux.py
+++ b/tests/test_coreir/test_coreir_mux.py
@@ -51,7 +51,6 @@ def test_coreir_mux_4x3():
 
 def test_two_coreir_muxes():
     width = 2
-    cirb = CoreIRBackend()
     scope = Scope()
     inType = Array[ width, In(BitIn) ]
     outType = Array[ width, Out(Bit) ]
@@ -61,7 +60,7 @@ def test_two_coreir_muxes():
     coreir_mux = DefineCoreirMux(None)()
     coreir_mux(testcircuit.I[0], testcircuit.I[1], testcircuit.S)
     wire(coreir_mux.O, testcircuit.O[0])
-    cmux = CommonlibMuxN(cirb, 2, 1)
+    cmux = CommonlibMuxN(2, 1)
     wire(cmux.I.data[0][0], testcircuit.I[0])
     wire(cmux.I.data[1][0], testcircuit.I[1])
     wire(cmux.I.sel[0], testcircuit.S)
@@ -69,5 +68,5 @@ def test_two_coreir_muxes():
 
     EndCircuit()
 
-    sim = CoreIRSimulator(testcircuit, testcircuit.CLK, context=cirb.context,
+    sim = CoreIRSimulator(testcircuit, testcircuit.CLK,
                           namespaces=["commonlib", "mantle", "coreir", "global"])

--- a/tests/test_spartan6/build/romb2048x8_coreir.v
+++ b/tests/test_spartan6/build/romb2048x8_coreir.v
@@ -1,8 +1,8 @@
 module test_romb (output [7:0] O, input  CLK);
-wire [31:0] inst0_DOA;
-wire [3:0] inst0_DOPA;
-wire [31:0] inst0_DOB;
-wire [3:0] inst0_DOPB;
+wire [31:0] RAMB16BWER_inst0_DOA;
+wire [3:0] RAMB16BWER_inst0_DOPA;
+wire [31:0] RAMB16BWER_inst0_DOB;
+wire [3:0] RAMB16BWER_inst0_DOPB;
 RAMB16BWER #(.DATA_WIDTH_A(9),
 .DATA_WIDTH_B(9),
 .INIT_00(256'h1F1E1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403020100),
@@ -74,7 +74,7 @@ RAMB16BWER #(.DATA_WIDTH_A(9),
 .SRVAL_A(8'h00),
 .SRVAL_B(8'h00),
 .WRITE_MODE_A("WRITE_FIRST"),
-.WRITE_MODE_B("WRITE_FIRST")) inst0 (.DIA({1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0}), .DIPA({1'b0,1'b0,1'b0,1'b0}), .DOA(inst0_DOA), .DOPA(inst0_DOPA), .ADDRA({1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b1,1'b0,1'b0,1'b0}), .CLKA(CLK), .ENA(1'b1), .WEA({1'b0,1'b0,1'b0,1'b0}), .RSTA(1'b0), .REGCEA(1'b0), .DOB(inst0_DOB), .DOPB(inst0_DOPB), .CLKB(1'b0), .ENB(1'b0), .WEB({1'b0,1'b0,1'b0,1'b0}), .RSTB(1'b0), .REGCEB(1'b0));
-assign O = {inst0_DOA[7],inst0_DOA[6],inst0_DOA[5],inst0_DOA[4],inst0_DOA[3],inst0_DOA[2],inst0_DOA[1],inst0_DOA[0]};
+.WRITE_MODE_B("WRITE_FIRST")) RAMB16BWER_inst0 (.DIA({1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0}), .DIPA({1'b0,1'b0,1'b0,1'b0}), .DOA(RAMB16BWER_inst0_DOA), .DOPA(RAMB16BWER_inst0_DOPA), .ADDRA({1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b1,1'b0,1'b0,1'b0}), .CLKA(CLK), .ENA(1'b1), .WEA({1'b0,1'b0,1'b0,1'b0}), .RSTA(1'b0), .REGCEA(1'b0), .DOB(RAMB16BWER_inst0_DOB), .DOPB(RAMB16BWER_inst0_DOPB), .CLKB(1'b0), .ENB(1'b0), .WEB({1'b0,1'b0,1'b0,1'b0}), .RSTB(1'b0), .REGCEB(1'b0));
+assign O = {RAMB16BWER_inst0_DOA[7],RAMB16BWER_inst0_DOA[6],RAMB16BWER_inst0_DOA[5],RAMB16BWER_inst0_DOA[4],RAMB16BWER_inst0_DOA[3],RAMB16BWER_inst0_DOA[2],RAMB16BWER_inst0_DOA[1],RAMB16BWER_inst0_DOA[0]};
 endmodule
 

--- a/tests/test_spartan6/gold/romb2048x8_coreir.v
+++ b/tests/test_spartan6/gold/romb2048x8_coreir.v
@@ -1,8 +1,8 @@
 module test_romb (output [7:0] O, input  CLK);
-wire [31:0] inst0_DOA;
-wire [3:0] inst0_DOPA;
-wire [31:0] inst0_DOB;
-wire [3:0] inst0_DOPB;
+wire [31:0] RAMB16BWER_inst0_DOA;
+wire [3:0] RAMB16BWER_inst0_DOPA;
+wire [31:0] RAMB16BWER_inst0_DOB;
+wire [3:0] RAMB16BWER_inst0_DOPB;
 RAMB16BWER #(.DATA_WIDTH_A(9),
 .DATA_WIDTH_B(9),
 .INIT_00(256'h1F1E1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403020100),
@@ -74,7 +74,7 @@ RAMB16BWER #(.DATA_WIDTH_A(9),
 .SRVAL_A(8'h00),
 .SRVAL_B(8'h00),
 .WRITE_MODE_A("WRITE_FIRST"),
-.WRITE_MODE_B("WRITE_FIRST")) inst0 (.DIA({1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0}), .DIPA({1'b0,1'b0,1'b0,1'b0}), .DOA(inst0_DOA), .DOPA(inst0_DOPA), .ADDRA({1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b1,1'b0,1'b0,1'b0}), .CLKA(CLK), .ENA(1'b1), .WEA({1'b0,1'b0,1'b0,1'b0}), .RSTA(1'b0), .REGCEA(1'b0), .DOB(inst0_DOB), .DOPB(inst0_DOPB), .CLKB(1'b0), .ENB(1'b0), .WEB({1'b0,1'b0,1'b0,1'b0}), .RSTB(1'b0), .REGCEB(1'b0));
-assign O = {inst0_DOA[7],inst0_DOA[6],inst0_DOA[5],inst0_DOA[4],inst0_DOA[3],inst0_DOA[2],inst0_DOA[1],inst0_DOA[0]};
+.WRITE_MODE_B("WRITE_FIRST")) RAMB16BWER_inst0 (.DIA({1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0}), .DIPA({1'b0,1'b0,1'b0,1'b0}), .DOA(RAMB16BWER_inst0_DOA), .DOPA(RAMB16BWER_inst0_DOPA), .ADDRA({1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b1,1'b0,1'b0,1'b0}), .CLKA(CLK), .ENA(1'b1), .WEA({1'b0,1'b0,1'b0,1'b0}), .RSTA(1'b0), .REGCEA(1'b0), .DOB(RAMB16BWER_inst0_DOB), .DOPB(RAMB16BWER_inst0_DOPB), .CLKB(1'b0), .ENB(1'b0), .WEB({1'b0,1'b0,1'b0,1'b0}), .RSTB(1'b0), .REGCEB(1'b0));
+assign O = {RAMB16BWER_inst0_DOA[7],RAMB16BWER_inst0_DOA[6],RAMB16BWER_inst0_DOA[5],RAMB16BWER_inst0_DOA[4],RAMB16BWER_inst0_DOA[3],RAMB16BWER_inst0_DOA[2],RAMB16BWER_inst0_DOA[1],RAMB16BWER_inst0_DOA[0]};
 endmodule
 


### PR DESCRIPTION
This commit updates CoreIR operators in Mantle to use the singleton CoreIR context and backend from https://github.com/phanrahan/magma/pull/408.