### PR TITLE
Add test for mux operator naming, update mantle3/6 to match coreir/ice40 Mux interface

### DIFF
--- a/mantle/xilinx/mantle3/MUX.py
+++ b/mantle/xilinx/mantle3/MUX.py
@@ -1,4 +1,5 @@
 from magma import *
+import magma as m
 from magma.bitutils import lutinit
 from ..spartan3.CLB import *
 
@@ -129,14 +130,14 @@ def MuxN(height, **kwargs):
     elif height == 16:
         return Mux16(**kwargs)
 
-def DefineMux(height=2, width=1):
+def DefineMux(height=2, width=1, T=None):
 
     """
     Construct a Mux. Height inputs are width bits wide.
     """
 
     assert height in [2, 4, 8, 16]
-    if width is None:
+    if width is None and (T is None or isinstance(T, m.BitKind)):
         if height == 2:
             return Mux2
         elif height == 4:
@@ -145,6 +146,9 @@ def DefineMux(height=2, width=1):
             return Mux8
         elif height == 16:
             return Mux16
+    if T is not None:
+        assert width is None, "Can only specify width **or** T"
+        width = len(T)
 
     class _Mux(Circuit):
         name = _MuxName(height, width)
@@ -168,8 +172,6 @@ def DefineMux(height=2, width=1):
             wire( mux.O, Mux.O )
     return _Mux
 
-def Mux(height=2, width=None, **kwargs):
-    if width is None:
-       return MuxN(height, **kwargs)
-    return DefineMux(height, width)(**kwargs)
+def Mux(height=2, width=None, T=None, **kwargs):
+    return DefineMux(height, width, T)(**kwargs)
 

--- a/mantle/xilinx/mantle6/MUX.py
+++ b/mantle/xilinx/mantle6/MUX.py
@@ -1,4 +1,5 @@
 from magma import *
+import magma as m
 from magma.bitutils import lutinit
 from ..spartan6.CLB import *
 
@@ -120,14 +121,14 @@ def MuxN(height, **kwargs):
     elif height == 16:
         return Mux16(**kwargs)
 
-def DefineMux(height=2, width=1):
+def DefineMux(height=2, width=1, T=None):
 
     """
     Construct a Mux. Height inputs are width bits wide.
     """
 
     assert height in [2, 4, 8, 16]
-    if width is None:
+    if width is None and (T is None or isinstance(T, m.BitKind)):
         if height == 2:
             return Mux2
         elif height == 4:
@@ -136,6 +137,9 @@ def DefineMux(height=2, width=1):
             return Mux8
         elif height == 16:
             return Mux16
+    if T is not None:
+        assert width is None, "Can only specify width **or** T"
+        width = len(T)
 
     class _Mux(Circuit):
         name = _MuxName(height, width)
@@ -159,8 +163,6 @@ def DefineMux(height=2, width=1):
             wire( mux.O, Mux.O )
     return _Mux
 
-def Mux(height=2, width=None, **kwargs):
-    if width is None:
-       return MuxN(height, **kwargs)
-    return DefineMux(height, width)(**kwargs)
+def Mux(height=2, width=None, T=None, **kwargs):
+    return DefineMux(height, width, T)(**kwargs)
 

--- a/tests/test_mantle/gold/test_mantle_mux_coreir.json
+++ b/tests/test_mantle/gold/test_mantle_mux_coreir.json
@@ -1,0 +1,47 @@
+{"top":"global.Test",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Mux2xOutBits10":{
+        "type":["Record",[
+          ["I0",["Array",10,"BitIn"]],
+          ["I1",["Array",10,"BitIn"]],
+          ["S","BitIn"],
+          ["O",["Array",10,"Bit"]]
+        ]],
+        "instances":{
+          "coreir_commonlib_mux2x10_inst0":{
+            "genref":"commonlib.muxn",
+            "genargs":{"N":["Int",2], "width":["Int",10]}
+          }
+        },
+        "connections":[
+          ["self.I0","coreir_commonlib_mux2x10_inst0.in.data.0"],
+          ["self.I1","coreir_commonlib_mux2x10_inst0.in.data.1"],
+          ["self.S","coreir_commonlib_mux2x10_inst0.in.sel.0"],
+          ["self.O","coreir_commonlib_mux2x10_inst0.out"]
+        ]
+      },
+      "Test":{
+        "type":["Record",[
+          ["I0",["Array",10,"BitIn"]],
+          ["I1",["Array",10,"BitIn"]],
+          ["S","BitIn"],
+          ["O",["Array",10,"Bit"]]
+        ]],
+        "instances":{
+          "my_mux":{
+            "modref":"global.Mux2xOutBits10"
+          }
+        },
+        "connections":[
+          ["self.I0","my_mux.I0"],
+          ["self.I1","my_mux.I1"],
+          ["self.O","my_mux.O"],
+          ["self.S","my_mux.S"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_mantle/gold/test_mantle_mux_ice40.v
+++ b/tests/test_mantle/gold/test_mantle_mux_ice40.v
@@ -1,0 +1,36 @@
+module Mux2 (input [1:0] I, input  S, output  O);
+wire  SB_LUT4_inst0_O;
+SB_LUT4 #(.LUT_INIT(16'hCACA)) SB_LUT4_inst0 (.I0(I[0]), .I1(I[1]), .I2(S), .I3(1'b0), .O(SB_LUT4_inst0_O));
+assign O = SB_LUT4_inst0_O;
+endmodule
+
+module Mux2x10 (input [9:0] I0, input [9:0] I1, input  S, output [9:0] O);
+wire  Mux2_inst0_O;
+wire  Mux2_inst1_O;
+wire  Mux2_inst2_O;
+wire  Mux2_inst3_O;
+wire  Mux2_inst4_O;
+wire  Mux2_inst5_O;
+wire  Mux2_inst6_O;
+wire  Mux2_inst7_O;
+wire  Mux2_inst8_O;
+wire  Mux2_inst9_O;
+Mux2 Mux2_inst0 (.I({I1[0],I0[0]}), .S(S), .O(Mux2_inst0_O));
+Mux2 Mux2_inst1 (.I({I1[1],I0[1]}), .S(S), .O(Mux2_inst1_O));
+Mux2 Mux2_inst2 (.I({I1[2],I0[2]}), .S(S), .O(Mux2_inst2_O));
+Mux2 Mux2_inst3 (.I({I1[3],I0[3]}), .S(S), .O(Mux2_inst3_O));
+Mux2 Mux2_inst4 (.I({I1[4],I0[4]}), .S(S), .O(Mux2_inst4_O));
+Mux2 Mux2_inst5 (.I({I1[5],I0[5]}), .S(S), .O(Mux2_inst5_O));
+Mux2 Mux2_inst6 (.I({I1[6],I0[6]}), .S(S), .O(Mux2_inst6_O));
+Mux2 Mux2_inst7 (.I({I1[7],I0[7]}), .S(S), .O(Mux2_inst7_O));
+Mux2 Mux2_inst8 (.I({I1[8],I0[8]}), .S(S), .O(Mux2_inst8_O));
+Mux2 Mux2_inst9 (.I({I1[9],I0[9]}), .S(S), .O(Mux2_inst9_O));
+assign O = {Mux2_inst9_O,Mux2_inst8_O,Mux2_inst7_O,Mux2_inst6_O,Mux2_inst5_O,Mux2_inst4_O,Mux2_inst3_O,Mux2_inst2_O,Mux2_inst1_O,Mux2_inst0_O};
+endmodule
+
+module Test (input [9:0] I0, input [9:0] I1, input  S, output [9:0] O);
+wire [9:0] my_mux_O;
+Mux2x10 my_mux (.I0(I0), .I1(I1), .S(S), .O(my_mux_O));
+assign O = my_mux_O;
+endmodule
+

--- a/tests/test_mantle/gold/test_mantle_mux_spartan3.v
+++ b/tests/test_mantle/gold/test_mantle_mux_spartan3.v
@@ -1,0 +1,36 @@
+module Mux2 (input [1:0] I, input  S, output  O);
+wire  LUT3_inst0_O;
+LUT3 #(.INIT(8'hCA)) LUT3_inst0 (.I0(I[0]), .I1(I[1]), .I2(S), .O(LUT3_inst0_O));
+assign O = LUT3_inst0_O;
+endmodule
+
+module Mux2x10 (input [9:0] I0, input [9:0] I1, input  S, output [9:0] O);
+wire  Mux2_inst0_O;
+wire  Mux2_inst1_O;
+wire  Mux2_inst2_O;
+wire  Mux2_inst3_O;
+wire  Mux2_inst4_O;
+wire  Mux2_inst5_O;
+wire  Mux2_inst6_O;
+wire  Mux2_inst7_O;
+wire  Mux2_inst8_O;
+wire  Mux2_inst9_O;
+Mux2 Mux2_inst0 (.I({I1[0],I0[0]}), .S(S), .O(Mux2_inst0_O));
+Mux2 Mux2_inst1 (.I({I1[1],I0[1]}), .S(S), .O(Mux2_inst1_O));
+Mux2 Mux2_inst2 (.I({I1[2],I0[2]}), .S(S), .O(Mux2_inst2_O));
+Mux2 Mux2_inst3 (.I({I1[3],I0[3]}), .S(S), .O(Mux2_inst3_O));
+Mux2 Mux2_inst4 (.I({I1[4],I0[4]}), .S(S), .O(Mux2_inst4_O));
+Mux2 Mux2_inst5 (.I({I1[5],I0[5]}), .S(S), .O(Mux2_inst5_O));
+Mux2 Mux2_inst6 (.I({I1[6],I0[6]}), .S(S), .O(Mux2_inst6_O));
+Mux2 Mux2_inst7 (.I({I1[7],I0[7]}), .S(S), .O(Mux2_inst7_O));
+Mux2 Mux2_inst8 (.I({I1[8],I0[8]}), .S(S), .O(Mux2_inst8_O));
+Mux2 Mux2_inst9 (.I({I1[9],I0[9]}), .S(S), .O(Mux2_inst9_O));
+assign O = {Mux2_inst9_O,Mux2_inst8_O,Mux2_inst7_O,Mux2_inst6_O,Mux2_inst5_O,Mux2_inst4_O,Mux2_inst3_O,Mux2_inst2_O,Mux2_inst1_O,Mux2_inst0_O};
+endmodule
+
+module Test (input [9:0] I0, input [9:0] I1, input  S, output [9:0] O);
+wire [9:0] my_mux_O;
+Mux2x10 my_mux (.I0(I0), .I1(I1), .S(S), .O(my_mux_O));
+assign O = my_mux_O;
+endmodule
+

--- a/tests/test_mantle/gold/test_mantle_mux_spartan6.v
+++ b/tests/test_mantle/gold/test_mantle_mux_spartan6.v
@@ -1,0 +1,36 @@
+module Mux2 (input [1:0] I, input  S, output  O);
+wire  LUT3_inst0_O;
+LUT3 #(.INIT(8'hCA)) LUT3_inst0 (.I0(I[0]), .I1(I[1]), .I2(S), .O(LUT3_inst0_O));
+assign O = LUT3_inst0_O;
+endmodule
+
+module Mux2x10 (input [9:0] I0, input [9:0] I1, input  S, output [9:0] O);
+wire  Mux2_inst0_O;
+wire  Mux2_inst1_O;
+wire  Mux2_inst2_O;
+wire  Mux2_inst3_O;
+wire  Mux2_inst4_O;
+wire  Mux2_inst5_O;
+wire  Mux2_inst6_O;
+wire  Mux2_inst7_O;
+wire  Mux2_inst8_O;
+wire  Mux2_inst9_O;
+Mux2 Mux2_inst0 (.I({I1[0],I0[0]}), .S(S), .O(Mux2_inst0_O));
+Mux2 Mux2_inst1 (.I({I1[1],I0[1]}), .S(S), .O(Mux2_inst1_O));
+Mux2 Mux2_inst2 (.I({I1[2],I0[2]}), .S(S), .O(Mux2_inst2_O));
+Mux2 Mux2_inst3 (.I({I1[3],I0[3]}), .S(S), .O(Mux2_inst3_O));
+Mux2 Mux2_inst4 (.I({I1[4],I0[4]}), .S(S), .O(Mux2_inst4_O));
+Mux2 Mux2_inst5 (.I({I1[5],I0[5]}), .S(S), .O(Mux2_inst5_O));
+Mux2 Mux2_inst6 (.I({I1[6],I0[6]}), .S(S), .O(Mux2_inst6_O));
+Mux2 Mux2_inst7 (.I({I1[7],I0[7]}), .S(S), .O(Mux2_inst7_O));
+Mux2 Mux2_inst8 (.I({I1[8],I0[8]}), .S(S), .O(Mux2_inst8_O));
+Mux2 Mux2_inst9 (.I({I1[9],I0[9]}), .S(S), .O(Mux2_inst9_O));
+assign O = {Mux2_inst9_O,Mux2_inst8_O,Mux2_inst7_O,Mux2_inst6_O,Mux2_inst5_O,Mux2_inst4_O,Mux2_inst3_O,Mux2_inst2_O,Mux2_inst1_O,Mux2_inst0_O};
+endmodule
+
+module Test (input [9:0] I0, input [9:0] I1, input  S, output [9:0] O);
+wire [9:0] my_mux_O;
+Mux2x10 my_mux (.I0(I0), .I1(I1), .S(S), .O(my_mux_O));
+assign O = my_mux_O;
+endmodule
+

--- a/tests/test_mantle/test_operator.py
+++ b/tests/test_mantle/test_operator.py
@@ -1,0 +1,26 @@
+import magma as m
+from magma.testing import check_files_equal
+import mantle
+
+
+def test_mux():
+    class Test(m.Circuit):
+        IO = ["I0", m.In(m.Bits[10]),
+              "I1", m.In(m.Bits[10]),
+              "S", m.In(m.Bit),
+              "O", m.Out(m.Bits[10])]
+        @classmethod
+        def definition(io):
+            io.O <= mantle.mux([io.I0, io.I1], io.S, name="my_mux")
+
+    if m.mantle_target == "coreir":
+        output = "coreir"
+        suffix = "json"
+    else:
+        output = "verilog"
+        suffix = "v"
+    m.compile(f"build/test_mantle_mux_{m.mantle_target}", Test, output)
+    assert check_files_equal(
+        __file__,
+        f"build/test_mantle_mux_{m.mantle_target}.{suffix}",
+        f"gold/test_mantle_mux_{m.mantle_target}.{suffix}")


### PR DESCRIPTION
This adds a test for naming the instance of a mux produced by `mantle.mux(I, S, name="...")`.  This revealed an inconsistency between the coreir/ice40 Mux interface and mantle3/6 Mux interface, so they have been updated to accept `T` as a generator parameter (as an alternative to passing in a width explicitly, this just gets the width from T).