### PR TITLE
Patch reg debug name

### DIFF
--- a/mantle/coreir/FF.py
+++ b/mantle/coreir/FF.py
@@ -129,9 +129,9 @@ def DefineDFF(init=0, has_ce=False, has_reset=False, has_async_reset=False, has_
     circ = DefineCircuit("DFF_init{}_has_ce{}_has_reset{}_has_async_reset{}".format(
         init, has_ce, has_reset, has_async_reset, has_async_resetn),
         *IO)
-    reg = Reg()
-    wiredefaultclock(circ, reg)
-    wireclock(circ, reg)
+    value = Reg()
+    wiredefaultclock(circ, value)
+    wireclock(circ, value)
     I = circ.I
     if has_reset and (has_async_reset or has_async_resetn):
         raise ValueError("Cannot have synchronous and asynchronous reset")
@@ -140,9 +140,9 @@ def DefineDFF(init=0, has_ce=False, has_reset=False, has_async_reset=False, has_
     if has_reset:
         I = Mux()(circ.I, bit(init), circ.RESET)
     if has_ce:
-        I = Mux()(reg.O[0], I, circ.CE)
-    wire(I, reg.I[0])
-    wire(reg.O[0], circ.O)
+        I = Mux()(value.O[0], I, circ.CE)
+    wire(I, value.I[0])
+    wire(value.O[0], circ.O)
     EndDefine()
     return circ
 

--- a/tests/test_coreir/gold/test_coreir_dff_debug_no_reg.json
+++ b/tests/test_coreir/gold/test_coreir_dff_debug_no_reg.json
@@ -1,0 +1,58 @@
+{"top":"global.DFF_init0_has_ceFalse_has_resetTrue_has_async_resetFalse",
+"namespaces":{
+  "global":{
+    "modules":{
+      "DFF_init0_has_ceFalse_has_resetTrue_has_async_resetFalse":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"],
+          ["CLK",["Named","coreir.clkIn"]],
+          ["RESET","BitIn"]
+        ]],
+        "instances":{
+          "Mux2xNone_inst0":{
+            "modref":"global.Mux2xNone"
+          },
+          "bit_const_0_None":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",false]}
+          },
+          "value":{
+            "genref":"coreir.reg",
+            "genargs":{"width":["Int",1]},
+            "modargs":{"clk_posedge":["Bool",true], "init":[["BitVector",1],"1'h0"]}
+          }
+        },
+        "connections":[
+          ["self.I","Mux2xNone_inst0.I0"],
+          ["bit_const_0_None.out","Mux2xNone_inst0.I1"],
+          ["value.in.0","Mux2xNone_inst0.O"],
+          ["self.RESET","Mux2xNone_inst0.S"],
+          ["value.clk","self.CLK"],
+          ["value.out.0","self.O"]
+        ]
+      },
+      "Mux2xNone":{
+        "type":["Record",[
+          ["I0","BitIn"],
+          ["I1","BitIn"],
+          ["S","BitIn"],
+          ["O","Bit"]
+        ]],
+        "instances":{
+          "mux":{
+            "genref":"commonlib.muxn",
+            "genargs":{"N":["Int",2], "width":["Int",1]}
+          }
+        },
+        "connections":[
+          ["self.I0","mux.in.data.0.0"],
+          ["self.I1","mux.in.data.1.0"],
+          ["self.S","mux.in.sel.0"],
+          ["self.O","mux.out.0"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_coreir/test_coreir_ff.py
+++ b/tests/test_coreir/test_coreir_ff.py
@@ -1,3 +1,4 @@
+import magma as m
 from magma import *
 from magma.testing import check_files_equal
 from mantle.coreir import DefineDFF
@@ -13,7 +14,16 @@ def test_ff():
 def test_ff_has_reset():
     DFF = DefineDFF(has_reset=True)
     print(repr(DFF))
-    compile("build/test_coreir_dff_reset", DFF, output="coreir")
+    compile("build/test_coreir_dff_reset", DFF, output="coreir-verilog")
     assert check_files_equal(__file__,
             "build/test_coreir_dff_reset.json", "gold/test_coreir_dff_reset.json")
 
+
+def test_no_reg():
+    m.config.set_debug_mode(True)
+    DFF = DefineDFF(has_reset=True)
+    print(repr(DFF))
+    compile("build/test_coreir_dff_debug_no_reg", DFF, output="coreir-verilog")
+    assert check_files_equal(__file__,
+            "build/test_coreir_dff_debug_no_reg.json", "gold/test_coreir_dff_debug_no_reg.json")
+    m.config.set_debug_mode(False)

--- a/tests/test_coreir/test_coreir_ff.py
+++ b/tests/test_coreir/test_coreir_ff.py
@@ -14,7 +14,7 @@ def test_ff():
 def test_ff_has_reset():
     DFF = DefineDFF(has_reset=True)
     print(repr(DFF))
-    compile("build/test_coreir_dff_reset", DFF, output="coreir-verilog")
+    compile("build/test_coreir_dff_reset", DFF, output="coreir")
     assert check_files_equal(__file__,
             "build/test_coreir_dff_reset.json", "gold/test_coreir_dff_reset.json")
 


### PR DESCRIPTION
Fixes an issue where when magma debug mode is enabled, the python variable name "reg" is captured as an instance name for the internal register.  This is a reserved verilog keyword, so we rename it `value` to avoid this issue (see https://github.com/phanrahan/mantle/compare/patch-reg-debug-name?expand=1#diff-73b80454f9f00f0fb6927abeeab83185R20 for the expected output)