### PR TITLE
Hwtypes2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ before_install:
 install:
 - pip install pytest-cov
 - pip install delegator.py
+- pip install -e git+git://github.com/phanrahan/magma.git@hwtypes2#egg=magma-lang
+- pip install -e git+git://github.com/leonardt/fault.git@hwtypes2#egg=fault
 - pip install -e .
 script:
 - "./scripts/run_tests.sh"

--- a/mantle/coreir/MUX.py
+++ b/mantle/coreir/MUX.py
@@ -105,8 +105,7 @@ def DefineMux(height=2, width=None, T=None):
                 if T is None and width is None or issubclass(T, m.Digital):
                     mux = _declare_muxn(height, 1)()
                 else:
-                    mux = _declare_muxn(height, width if T is None else
-                                        len(T))()
+                    mux = _declare_muxn(height, width if T is None else len(T))()
                 for i in range(height):
                     if T is None and width is None or issubclass(T, m.Digital):
                         m.wire(getattr(interface, f"I{i}"), mux.I.data[i][0])

--- a/mantle/coreir/MUX.py
+++ b/mantle/coreir/MUX.py
@@ -50,8 +50,9 @@ def _declare_muxn(height, width):
         out = BitVector[width](value_store.get_value(self.I.data[sel.as_int]))
         value_store.set_value(self.O, out)
     return DeclareCoreirCircuit(f"coreir_commonlib_mux{height}x{width}",
-        *["I", In(Tuple(data=Array[height, Bits[width]],
-                         sel=Bits[m.bitutils.clog2(height)])),
+        *["I", In(Product.from_fields("anon",
+                                      dict(data=Array[height, Bits[width]],
+                                           sel=Bits[m.bitutils.clog2(height)]))),
           "O", Out(Bits[width])],
         coreir_name="muxn",
         coreir_lib="commonlib",
@@ -90,23 +91,24 @@ def DefineMux(height=2, width=None, T=None):
         IO = io
         @classmethod
         def definition(interface):
-            if T is not None and not (isinstance(T, m.BitKind) or isinstance(T, m.ArrayKind) and isinstance(T.T, m.BitKind)):
+            if T is not None and not (issubclass(T, m.Digital) or issubclass(T, m.Array) and issubclass(T.T, m.Bit)):
                 if isinstance(T, m.TupleKind):
-                    for i in range(len(T.Ks)):
-                        Is = [getattr(interface, f"I{j}")[T.Ks[i]] for j in range(height)]
-                        interface.O[i] <= DefineMux(height, T=T.Ts[i])()(*Is, interface.S)
+                    for i in range(len(T.keys())):
+                        Is = [getattr(interface, f"I{j}")[list(T.keys())[i]] for j in range(height)]
+                        interface.O[i] <= DefineMux(height, T=list(T.types())[i])()(*Is, interface.S)
                 else:
                     assert isinstance(T, m.ArrayKind), f"Expected array or type type, got {T}, type is {type(T)}"
                     for i in range(len(T)):
                         Is = [getattr(interface, f"I{j}")[i] for j in range(height)]
                         interface.O[i] <= DefineMux(height, T=type(Is[0]))()(*Is, interface.S)
             else:
-                if T is None and width is None or isinstance(T, m.BitKind):
+                if T is None and width is None or issubclass(T, m.Digital):
                     mux = _declare_muxn(height, 1)()
                 else:
-                    mux = _declare_muxn(height, width if T is None else T.size())()
+                    mux = _declare_muxn(height, width if T is None else
+                                        len(T))()
                 for i in range(height):
-                    if T is None and width is None or isinstance(T, m.BitKind):
+                    if T is None and width is None or issubclass(T, m.Digital):
                         m.wire(getattr(interface, f"I{i}"), mux.I.data[i][0])
                     else:
                         m.wire(getattr(interface, f"I{i}"), mux.I.data[i])
@@ -114,7 +116,7 @@ def DefineMux(height=2, width=None, T=None):
                     m.wire(interface.S, mux.I.sel[0])
                 else:
                     m.wire(interface.S, mux.I.sel)
-                if T is None and width is None or isinstance(T, m.BitKind):
+                if T is None and width is None or issubclass(T, m.Digital):
                     wire(mux.O[0], interface.O)
                 else:
                     wire(mux.O, interface.O)

--- a/mantle/coreir/arith.py
+++ b/mantle/coreir/arith.py
@@ -32,7 +32,7 @@ def declare_binop(name, python_op, out_type=None, signed=False):
                                   coreir_name=name,
                                   coreir_lib = "corebit")
         else:
-            if isinstance(T, m.BFloatKind):
+            if issubclass(T, m.BFloat):
                 coreir_lib = "float"
                 if T.N != 16:
                     raise NotImplementedError("Only BFloat16 supported")
@@ -60,7 +60,7 @@ def DefineCoreirAdd(width, T=m.Bits):
         I0 = BitVector[width](value_store.get_value(self.I0))
         I1 = BitVector[width](value_store.get_value(self.I1))
         value_store.set_value(self.O, I0 + I1)
-    if isinstance(T, m.BFloatKind):
+    if issubclass(T, m.BFloat):
         coreir_lib = "float"
         if T.N != 16:
             raise NotImplementedError("Only BFloat16 supported")

--- a/mantle/coreir/logic.py
+++ b/mantle/coreir/logic.py
@@ -1,4 +1,5 @@
 from magma import *
+import magma as m
 from hwtypes import BitVector
 import hwtypes as ht
 from magma.compatibility import IntegerTypes
@@ -8,9 +9,9 @@ from .util import DeclareCoreirCircuit
 
 
 def get_length(value):
-    if isinstance(value, (BitType, ClockType, EnableType, ResetType)):
+    if isinstance(value, m.Digital):
         return None
-    elif isinstance(value, ArrayType):
+    elif isinstance(value, m.Array):
         return len(value)
     else:
         raise NotImplementedError("Cannot get_length of"

--- a/mantle/lattice/mantle40/MUX.py
+++ b/mantle/lattice/mantle40/MUX.py
@@ -165,10 +165,10 @@ def DefineMux(height=2, width=1):
 def Mux(height=2, width=None, T=None, **kwargs):
     if T is not None:
         assert width is None, "Can only specify width **or** T"
-        if isinstance(T, m.BitKind):
+        if issubclass(T, m.Bit):
             width = None
-        elif isinstance(T, m.BitsKind) or \
-                isinstance(T, m.ArrayKind) and isinstance(T.T, m.BitKind):
+        elif issubclass(T, m.Bits) or \
+                issubclass(T, m.Array) and issubclass(T.T, m.Bit):
             width = len(T)
         else:
             raise NotImplementedError(type(T))

--- a/mantle/xilinx/mantle3/MUX.py
+++ b/mantle/xilinx/mantle3/MUX.py
@@ -137,7 +137,7 @@ def DefineMux(height=2, width=1, T=None):
     """
 
     assert height in [2, 4, 8, 16]
-    if width is None and (T is None or isinstance(T, m.BitKind)):
+    if width is None and (T is None or issubclass(T, m.Digital)):
         if height == 2:
             return Mux2
         elif height == 4:

--- a/mantle/xilinx/mantle6/MUX.py
+++ b/mantle/xilinx/mantle6/MUX.py
@@ -128,7 +128,7 @@ def DefineMux(height=2, width=1, T=None):
     """
 
     assert height in [2, 4, 8, 16]
-    if width is None and (T is None or isinstance(T, m.BitKind)):
+    if width is None and (T is None or issubclass(T, m.Digital)):
         if height == 2:
             return Mux2
         elif height == 4:

--- a/tests/test_coreir/test_coreir_mux.py
+++ b/tests/test_coreir/test_coreir_mux.py
@@ -25,8 +25,8 @@ def test_coreir_mux_2x3():
 
 
 def test_coreir_mux_2xTuple():
-    A = Tuple(a=Bit, b=Bits[2])
-    B = Tuple(a=A, b=Bits[3])
+    A = Product.from_fields("anon", dict(a=Bit, b=Bits[2]))
+    B = Product.from_fields("anon", dict(a=A, b=Bits[3]))
     mux = DefineMux(2, T=B)
     print(repr(mux))
     compile("build/test_coreir_mux2xTuple", mux, output="coreir")

--- a/tests/test_coreir/test_operator.py
+++ b/tests/test_coreir/test_operator.py
@@ -1,186 +1,28 @@
-# import pytest
-# import magma as m
-# import mantle
-# from magma.testing import check_files_equal
-# from collections import namedtuple
-# import fault
-# from hwtypes import BitVector
-
-# op = namedtuple("op", ["name", "operator"])
+import magma as m
+from magma.testing import check_files_equal
+import fault
+from hwtypes import BitVector
 
 
-# @pytest.mark.parametrize("op", [
-#     op(name="invert", operator="~"),
-#     op(name="neg", operator="-"),
-# ])
-# @pytest.mark.parametrize("N", [4])
-# @pytest.mark.parametrize("T,TType", [(m.Bit, m.BitType),
-#                                      (m.UInt, m.UIntType),
-#                                      (m.SInt, m.SIntType),
-#                                      (m.Bits, m.BitsType)])
-# def test_unary_op(op, N, T, TType):
-#     """
-#     Tests mantle.operator by using the operator.{op.name} method directly and
-#     using the overloaded {op.operator} if it is not None.
-#     """
-#     if op.name == "neg" and T is not m.UInt and T is not m.SInt:
-#         return
+def test_dyanmic_mux_getitem():
+    class TestDynamicMuxGetItem(m.Circuit):
+        IO = ["I", m.In(m.Bits[ 2 ]), "S", m.In(m.Bit), "O", m.Out(m.Bit)]
 
-#     def to_str(x):
-#         if callable(x):
-#             return x.__name__
-#         return str(x)
-#     _name = "TestsCircuit_" + \
-#         "_".join(to_str(x) for x in (op.name, N, T, T.__name__ + "Type"))
-#     # List of comparison ops so we can special case them (output type and
-#     # wiring 0)
-#     comparisons = ["lt", "le", "gt", "ge"]
-#     if op.name in comparisons + ["eq", "ne"] or T is m.Bit:
-#         out_T = m.Out(m.Bit)
-#         expected_res_type = m.BitType
-#     else:
-#         out_T = m.Out(T[N])
-#         expected_res_type = TType
+        @classmethod
+        def definition(io):
+            m.wire(io.O, io.I[io.S])
+    m.compile("build/test_dynamic_mux_getitem", TestDynamicMuxGetItem,
+              output="coreir")
+    assert check_files_equal(__file__, f"build/test_dynamic_mux_getitem.json",
+                             f"gold/test_dynamic_mux_getitem.json")
 
-#     if T is m.Bit:
-#         in_T = m.Bit
-#     else:
-#         in_T = T[N]
-
-#     class TestCircuit(m.Circuit):
-#         name = _name
-#         IO = ["I", m.In(in_T), "O0", out_T, "O1", out_T]
-
-#         @classmethod
-#         def definition(io):
-#             # Test using the method directly
-#             res = getattr(mantle, op.name)(io.I)
-#             assert isinstance(res, expected_res_type), type(res)
-#             m.wire(res, io.O0)
-#             # Test using the operator if it exists, otherwise wire 0 to O1
-#             if op.operator is None or (
-#                     op.name in ["sub", "add"] + comparisons and T == m.Bits):
-#                 if op.name in comparisons:
-#                     m.wire(0, io.O1)
-#                 else:
-#                     m.wire(m.bits(0, N), io.O1)
-#             else:
-#                 res_operator = eval(f"{op.operator} io.I")
-#                 m.wire(res_operator, io.O1)
-
-#     m.compile(f'build/{_name}', TestCircuit, output="coreir")
-#     assert check_files_equal(__file__, f"build/{_name}.json",
-#                              f"gold/{_name}.json")
-
-
-# @pytest.mark.parametrize("op", [
-#     op(name="and_", operator="&"),
-#     op(name="nand", operator=None),
-#     op(name="or_", operator="|"),
-#     op(name="nor", operator=None),
-#     op(name="xor", operator="^"),
-#     op(name="nxor", operator=None),
-#     op(name="lsl", operator="<<"),
-#     op(name="lsr", operator=">>"),
-#     op(name="add", operator="+"),
-#     op(name="sub", operator="-"),
-#     op(name="mul", operator="*"),
-#     op(name="udiv", operator="/"),
-#     op(name="sdiv", operator="/"),
-#     op(name="umod", operator="%"),
-#     op(name="smod", operator="%"),
-#     op(name="eq", operator="=="),
-#     op(name="ne", operator="!="),
-#     op(name="lt", operator="<"),
-#     op(name="le", operator="<="),
-#     op(name="gt", operator=">"),
-#     op(name="ge", operator=">="),
-# ])
-# @pytest.mark.parametrize("N", [4])
-# @pytest.mark.parametrize("T,TType", [(m.UInt, m.UIntType),
-#                                      (m.SInt, m.SIntType),
-#                                      (m.Bits, m.BitsType)])
-# def test_binary_op(op, N, T, TType):
-#     """
-#     Tests mantle.operator by using the operator.{op.name} method directly and
-#     using the overloaded {op.operator} if it is not None.
-#     """
-
-#     if op.name in ["mul"] and T is not m.UInt and T is not m.SInt:
-#         pytest.skip(f"{op.name} only defined for m.UInt and m.SInt")
-#     if op.name in ["udiv", "umod"] and T is not m.UInt:
-#         pytest.skip(f"{op.name} only defined for m.UInt")
-#     elif op.name in ["sdiv", "smod"] and T is not m.SInt:
-#         pytest.skip(f"{op.name} only defined for m.SInt")
-#     if op.name == "lsr" and T is m.SInt:
-#         # Redefine here because it's shadowed by the `op` param
-#         op_tuple = namedtuple("op", ["name", "operator"])
-#         op = op_tuple(name="asr", operator=">>")
-#     def to_str(x):
-#         if callable(x):
-#             return x.__name__
-#         return str(x)
-#     _name = "TestsCircuit_" + \
-#         "_".join(to_str(x) for x in (op.name, N, T, T.__name__ + "Type"))
-#     # List of comparison ops so we can special case them (output type and
-#     # wiring 0)
-#     comparisons = ["lt", "le", "gt", "ge"]
-#     if op.name in comparisons + ["eq", "ne"]:
-#         out_T = m.Out(m.Bit)
-#         expected_res_type = m.BitType
-#     else:
-#         out_T = m.Out(T[N])
-#         expected_res_type = TType
-
-#     class TestCircuit(m.Circuit):
-#         name = _name
-#         IO = ["I0", m.In(T[N]), "I1", m.In(T[N]),
-#               "O0", out_T, "O1", out_T, "O2", out_T]
-
-#         @classmethod
-#         def definition(io):
-#             # Test using the method directly
-#             res = getattr(mantle, op.name)(io.I0, io.I1)
-#             assert isinstance(res, expected_res_type), type(res)
-#             m.wire(res, io.O0)
-#             # Test using the operator if it exists, otherwise wire 0 to O1
-#             if op.operator is None or (
-#                     op.name in ["sub", "add"] + comparisons and T is m.Bits):
-#                 if op.name in comparisons:
-#                     m.wire(0, io.O1)
-#                 else:
-#                     m.wire(m.bits(0, N), io.O1)
-#             else:
-#                 res_operator = eval(f"io.I0 {op.operator} io.I1")
-#                 m.wire(res_operator, io.O1)
-#             # Test integer promotion
-#             res = getattr(mantle, op.name)(io.I0, 1)
-#             m.wire(res, io.O2)
-
-#     m.compile(f'build/{_name}', TestCircuit, output="coreir")
-#     assert check_files_equal(__file__, f"build/{_name}.json",
-#                              f"gold/{_name}.json")
-
-
-# def test_dyanmic_mux_getitem():
-#     class TestDynamicMuxGetItem(m.Circuit):
-#         IO = ["I", m.In(m.Bits[ 2 ]), "S", m.In(m.Bit), "O", m.Out(m.Bit)]
-
-#         @classmethod
-#         def definition(io):
-#             m.wire(io.O, io.I[io.S])
-#     m.compile("build/test_dynamic_mux_getitem", TestDynamicMuxGetItem,
-#               output="coreir")
-#     assert check_files_equal(__file__, f"build/test_dynamic_mux_getitem.json",
-#                              f"gold/test_dynamic_mux_getitem.json")
-
-#     tester = fault.Tester(TestDynamicMuxGetItem)
-#     tester.poke(TestDynamicMuxGetItem.I, BitVector[2](2))
-#     tester.poke(TestDynamicMuxGetItem.S, 0)
-#     tester.expect(TestDynamicMuxGetItem.O, 0)
-#     tester.eval()
-#     tester.expect(TestDynamicMuxGetItem.O, 0)
-#     tester.poke(TestDynamicMuxGetItem.S, 1)
-#     tester.eval()
-#     tester.expect(TestDynamicMuxGetItem.O, 1)
-#     tester.compile_and_run(target='coreir')
+    tester = fault.Tester(TestDynamicMuxGetItem)
+    tester.poke(TestDynamicMuxGetItem.I, BitVector[2](2))
+    tester.poke(TestDynamicMuxGetItem.S, 0)
+    tester.expect(TestDynamicMuxGetItem.O, 0)
+    tester.eval()
+    tester.expect(TestDynamicMuxGetItem.O, 0)
+    tester.poke(TestDynamicMuxGetItem.S, 1)
+    tester.eval()
+    tester.expect(TestDynamicMuxGetItem.O, 1)
+    tester.compile_and_run(target='coreir')

--- a/tests/test_coreir/test_operator.py
+++ b/tests/test_coreir/test_operator.py
@@ -1,186 +1,186 @@
-import pytest
-import magma as m
-import mantle
-from magma.testing import check_files_equal
-from collections import namedtuple
-import fault
-from hwtypes import BitVector
+# import pytest
+# import magma as m
+# import mantle
+# from magma.testing import check_files_equal
+# from collections import namedtuple
+# import fault
+# from hwtypes import BitVector
 
-op = namedtuple("op", ["name", "operator"])
-
-
-@pytest.mark.parametrize("op", [
-    op(name="invert", operator="~"),
-    op(name="neg", operator="-"),
-])
-@pytest.mark.parametrize("N", [4])
-@pytest.mark.parametrize("T,TType", [(m.Bit, m.BitType),
-                                     (m.UInt, m.UIntType),
-                                     (m.SInt, m.SIntType),
-                                     (m.Bits, m.BitsType)])
-def test_unary_op(op, N, T, TType):
-    """
-    Tests mantle.operator by using the operator.{op.name} method directly and
-    using the overloaded {op.operator} if it is not None.
-    """
-    if op.name == "neg" and T is not m.UInt and T is not m.SInt:
-        return
-
-    def to_str(x):
-        if callable(x):
-            return x.__name__
-        return str(x)
-    _name = "TestsCircuit_" + \
-        "_".join(to_str(x) for x in (op.name, N, T, T.__name__ + "Type"))
-    # List of comparison ops so we can special case them (output type and
-    # wiring 0)
-    comparisons = ["lt", "le", "gt", "ge"]
-    if op.name in comparisons + ["eq", "ne"] or T is m.Bit:
-        out_T = m.Out(m.Bit)
-        expected_res_type = m.BitType
-    else:
-        out_T = m.Out(T[N])
-        expected_res_type = TType
-
-    if T is m.Bit:
-        in_T = m.Bit
-    else:
-        in_T = T[N]
-
-    class TestCircuit(m.Circuit):
-        name = _name
-        IO = ["I", m.In(in_T), "O0", out_T, "O1", out_T]
-
-        @classmethod
-        def definition(io):
-            # Test using the method directly
-            res = getattr(mantle, op.name)(io.I)
-            assert isinstance(res, expected_res_type), type(res)
-            m.wire(res, io.O0)
-            # Test using the operator if it exists, otherwise wire 0 to O1
-            if op.operator is None or (
-                    op.name in ["sub", "add"] + comparisons and T == m.Bits):
-                if op.name in comparisons:
-                    m.wire(0, io.O1)
-                else:
-                    m.wire(m.bits(0, N), io.O1)
-            else:
-                res_operator = eval(f"{op.operator} io.I")
-                m.wire(res_operator, io.O1)
-
-    m.compile(f'build/{_name}', TestCircuit, output="coreir")
-    assert check_files_equal(__file__, f"build/{_name}.json",
-                             f"gold/{_name}.json")
+# op = namedtuple("op", ["name", "operator"])
 
 
-@pytest.mark.parametrize("op", [
-    op(name="and_", operator="&"),
-    op(name="nand", operator=None),
-    op(name="or_", operator="|"),
-    op(name="nor", operator=None),
-    op(name="xor", operator="^"),
-    op(name="nxor", operator=None),
-    op(name="lsl", operator="<<"),
-    op(name="lsr", operator=">>"),
-    op(name="add", operator="+"),
-    op(name="sub", operator="-"),
-    op(name="mul", operator="*"),
-    op(name="udiv", operator="/"),
-    op(name="sdiv", operator="/"),
-    op(name="umod", operator="%"),
-    op(name="smod", operator="%"),
-    op(name="eq", operator="=="),
-    op(name="ne", operator="!="),
-    op(name="lt", operator="<"),
-    op(name="le", operator="<="),
-    op(name="gt", operator=">"),
-    op(name="ge", operator=">="),
-])
-@pytest.mark.parametrize("N", [4])
-@pytest.mark.parametrize("T,TType", [(m.UInt, m.UIntType),
-                                     (m.SInt, m.SIntType),
-                                     (m.Bits, m.BitsType)])
-def test_binary_op(op, N, T, TType):
-    """
-    Tests mantle.operator by using the operator.{op.name} method directly and
-    using the overloaded {op.operator} if it is not None.
-    """
+# @pytest.mark.parametrize("op", [
+#     op(name="invert", operator="~"),
+#     op(name="neg", operator="-"),
+# ])
+# @pytest.mark.parametrize("N", [4])
+# @pytest.mark.parametrize("T,TType", [(m.Bit, m.BitType),
+#                                      (m.UInt, m.UIntType),
+#                                      (m.SInt, m.SIntType),
+#                                      (m.Bits, m.BitsType)])
+# def test_unary_op(op, N, T, TType):
+#     """
+#     Tests mantle.operator by using the operator.{op.name} method directly and
+#     using the overloaded {op.operator} if it is not None.
+#     """
+#     if op.name == "neg" and T is not m.UInt and T is not m.SInt:
+#         return
 
-    if op.name in ["mul"] and T is not m.UInt and T is not m.SInt:
-        pytest.skip(f"{op.name} only defined for m.UInt and m.SInt")
-    if op.name in ["udiv", "umod"] and T is not m.UInt:
-        pytest.skip(f"{op.name} only defined for m.UInt")
-    elif op.name in ["sdiv", "smod"] and T is not m.SInt:
-        pytest.skip(f"{op.name} only defined for m.SInt")
-    if op.name == "lsr" and T is m.SInt:
-        # Redefine here because it's shadowed by the `op` param
-        op_tuple = namedtuple("op", ["name", "operator"])
-        op = op_tuple(name="asr", operator=">>")
-    def to_str(x):
-        if callable(x):
-            return x.__name__
-        return str(x)
-    _name = "TestsCircuit_" + \
-        "_".join(to_str(x) for x in (op.name, N, T, T.__name__ + "Type"))
-    # List of comparison ops so we can special case them (output type and
-    # wiring 0)
-    comparisons = ["lt", "le", "gt", "ge"]
-    if op.name in comparisons + ["eq", "ne"]:
-        out_T = m.Out(m.Bit)
-        expected_res_type = m.BitType
-    else:
-        out_T = m.Out(T[N])
-        expected_res_type = TType
+#     def to_str(x):
+#         if callable(x):
+#             return x.__name__
+#         return str(x)
+#     _name = "TestsCircuit_" + \
+#         "_".join(to_str(x) for x in (op.name, N, T, T.__name__ + "Type"))
+#     # List of comparison ops so we can special case them (output type and
+#     # wiring 0)
+#     comparisons = ["lt", "le", "gt", "ge"]
+#     if op.name in comparisons + ["eq", "ne"] or T is m.Bit:
+#         out_T = m.Out(m.Bit)
+#         expected_res_type = m.BitType
+#     else:
+#         out_T = m.Out(T[N])
+#         expected_res_type = TType
 
-    class TestCircuit(m.Circuit):
-        name = _name
-        IO = ["I0", m.In(T[N]), "I1", m.In(T[N]),
-              "O0", out_T, "O1", out_T, "O2", out_T]
+#     if T is m.Bit:
+#         in_T = m.Bit
+#     else:
+#         in_T = T[N]
 
-        @classmethod
-        def definition(io):
-            # Test using the method directly
-            res = getattr(mantle, op.name)(io.I0, io.I1)
-            assert isinstance(res, expected_res_type), type(res)
-            m.wire(res, io.O0)
-            # Test using the operator if it exists, otherwise wire 0 to O1
-            if op.operator is None or (
-                    op.name in ["sub", "add"] + comparisons and T is m.Bits):
-                if op.name in comparisons:
-                    m.wire(0, io.O1)
-                else:
-                    m.wire(m.bits(0, N), io.O1)
-            else:
-                res_operator = eval(f"io.I0 {op.operator} io.I1")
-                m.wire(res_operator, io.O1)
-            # Test integer promotion
-            res = getattr(mantle, op.name)(io.I0, 1)
-            m.wire(res, io.O2)
+#     class TestCircuit(m.Circuit):
+#         name = _name
+#         IO = ["I", m.In(in_T), "O0", out_T, "O1", out_T]
 
-    m.compile(f'build/{_name}', TestCircuit, output="coreir")
-    assert check_files_equal(__file__, f"build/{_name}.json",
-                             f"gold/{_name}.json")
+#         @classmethod
+#         def definition(io):
+#             # Test using the method directly
+#             res = getattr(mantle, op.name)(io.I)
+#             assert isinstance(res, expected_res_type), type(res)
+#             m.wire(res, io.O0)
+#             # Test using the operator if it exists, otherwise wire 0 to O1
+#             if op.operator is None or (
+#                     op.name in ["sub", "add"] + comparisons and T == m.Bits):
+#                 if op.name in comparisons:
+#                     m.wire(0, io.O1)
+#                 else:
+#                     m.wire(m.bits(0, N), io.O1)
+#             else:
+#                 res_operator = eval(f"{op.operator} io.I")
+#                 m.wire(res_operator, io.O1)
+
+#     m.compile(f'build/{_name}', TestCircuit, output="coreir")
+#     assert check_files_equal(__file__, f"build/{_name}.json",
+#                              f"gold/{_name}.json")
 
 
-def test_dyanmic_mux_getitem():
-    class TestDynamicMuxGetItem(m.Circuit):
-        IO = ["I", m.In(m.Bits[ 2 ]), "S", m.In(m.Bit), "O", m.Out(m.Bit)]
+# @pytest.mark.parametrize("op", [
+#     op(name="and_", operator="&"),
+#     op(name="nand", operator=None),
+#     op(name="or_", operator="|"),
+#     op(name="nor", operator=None),
+#     op(name="xor", operator="^"),
+#     op(name="nxor", operator=None),
+#     op(name="lsl", operator="<<"),
+#     op(name="lsr", operator=">>"),
+#     op(name="add", operator="+"),
+#     op(name="sub", operator="-"),
+#     op(name="mul", operator="*"),
+#     op(name="udiv", operator="/"),
+#     op(name="sdiv", operator="/"),
+#     op(name="umod", operator="%"),
+#     op(name="smod", operator="%"),
+#     op(name="eq", operator="=="),
+#     op(name="ne", operator="!="),
+#     op(name="lt", operator="<"),
+#     op(name="le", operator="<="),
+#     op(name="gt", operator=">"),
+#     op(name="ge", operator=">="),
+# ])
+# @pytest.mark.parametrize("N", [4])
+# @pytest.mark.parametrize("T,TType", [(m.UInt, m.UIntType),
+#                                      (m.SInt, m.SIntType),
+#                                      (m.Bits, m.BitsType)])
+# def test_binary_op(op, N, T, TType):
+#     """
+#     Tests mantle.operator by using the operator.{op.name} method directly and
+#     using the overloaded {op.operator} if it is not None.
+#     """
 
-        @classmethod
-        def definition(io):
-            m.wire(io.O, io.I[io.S])
-    m.compile("build/test_dynamic_mux_getitem", TestDynamicMuxGetItem,
-              output="coreir")
-    assert check_files_equal(__file__, f"build/test_dynamic_mux_getitem.json",
-                             f"gold/test_dynamic_mux_getitem.json")
+#     if op.name in ["mul"] and T is not m.UInt and T is not m.SInt:
+#         pytest.skip(f"{op.name} only defined for m.UInt and m.SInt")
+#     if op.name in ["udiv", "umod"] and T is not m.UInt:
+#         pytest.skip(f"{op.name} only defined for m.UInt")
+#     elif op.name in ["sdiv", "smod"] and T is not m.SInt:
+#         pytest.skip(f"{op.name} only defined for m.SInt")
+#     if op.name == "lsr" and T is m.SInt:
+#         # Redefine here because it's shadowed by the `op` param
+#         op_tuple = namedtuple("op", ["name", "operator"])
+#         op = op_tuple(name="asr", operator=">>")
+#     def to_str(x):
+#         if callable(x):
+#             return x.__name__
+#         return str(x)
+#     _name = "TestsCircuit_" + \
+#         "_".join(to_str(x) for x in (op.name, N, T, T.__name__ + "Type"))
+#     # List of comparison ops so we can special case them (output type and
+#     # wiring 0)
+#     comparisons = ["lt", "le", "gt", "ge"]
+#     if op.name in comparisons + ["eq", "ne"]:
+#         out_T = m.Out(m.Bit)
+#         expected_res_type = m.BitType
+#     else:
+#         out_T = m.Out(T[N])
+#         expected_res_type = TType
 
-    tester = fault.Tester(TestDynamicMuxGetItem)
-    tester.poke(TestDynamicMuxGetItem.I, BitVector[2](2))
-    tester.poke(TestDynamicMuxGetItem.S, 0)
-    tester.expect(TestDynamicMuxGetItem.O, 0)
-    tester.eval()
-    tester.expect(TestDynamicMuxGetItem.O, 0)
-    tester.poke(TestDynamicMuxGetItem.S, 1)
-    tester.eval()
-    tester.expect(TestDynamicMuxGetItem.O, 1)
-    tester.compile_and_run(target='coreir')
+#     class TestCircuit(m.Circuit):
+#         name = _name
+#         IO = ["I0", m.In(T[N]), "I1", m.In(T[N]),
+#               "O0", out_T, "O1", out_T, "O2", out_T]
+
+#         @classmethod
+#         def definition(io):
+#             # Test using the method directly
+#             res = getattr(mantle, op.name)(io.I0, io.I1)
+#             assert isinstance(res, expected_res_type), type(res)
+#             m.wire(res, io.O0)
+#             # Test using the operator if it exists, otherwise wire 0 to O1
+#             if op.operator is None or (
+#                     op.name in ["sub", "add"] + comparisons and T is m.Bits):
+#                 if op.name in comparisons:
+#                     m.wire(0, io.O1)
+#                 else:
+#                     m.wire(m.bits(0, N), io.O1)
+#             else:
+#                 res_operator = eval(f"io.I0 {op.operator} io.I1")
+#                 m.wire(res_operator, io.O1)
+#             # Test integer promotion
+#             res = getattr(mantle, op.name)(io.I0, 1)
+#             m.wire(res, io.O2)
+
+#     m.compile(f'build/{_name}', TestCircuit, output="coreir")
+#     assert check_files_equal(__file__, f"build/{_name}.json",
+#                              f"gold/{_name}.json")
+
+
+# def test_dyanmic_mux_getitem():
+#     class TestDynamicMuxGetItem(m.Circuit):
+#         IO = ["I", m.In(m.Bits[ 2 ]), "S", m.In(m.Bit), "O", m.Out(m.Bit)]
+
+#         @classmethod
+#         def definition(io):
+#             m.wire(io.O, io.I[io.S])
+#     m.compile("build/test_dynamic_mux_getitem", TestDynamicMuxGetItem,
+#               output="coreir")
+#     assert check_files_equal(__file__, f"build/test_dynamic_mux_getitem.json",
+#                              f"gold/test_dynamic_mux_getitem.json")
+
+#     tester = fault.Tester(TestDynamicMuxGetItem)
+#     tester.poke(TestDynamicMuxGetItem.I, BitVector[2](2))
+#     tester.poke(TestDynamicMuxGetItem.S, 0)
+#     tester.expect(TestDynamicMuxGetItem.O, 0)
+#     tester.eval()
+#     tester.expect(TestDynamicMuxGetItem.O, 0)
+#     tester.poke(TestDynamicMuxGetItem.S, 1)
+#     tester.eval()
+#     tester.expect(TestDynamicMuxGetItem.O, 1)
+#     tester.compile_and_run(target='coreir')


### PR DESCRIPTION
Summary of changes
* operator definitions moved to magma
* Rename `<..>Type` to `<...>`. No more type constructors (e.g. `ArrayType` becomes `Array`)
* `isinstance(..., <...>Kind)`  -> `issubclass(..., <...>)`. Concrete parameterized types are subclasses of the abstract type) (e.g. `isinstance(T, BitsKind)` becomes `issubclass(T, Bits)`
* `_Bit` -> `Digital`. Renamed parent type of Bit, Clock, Reset, ...
* `Tuple(...)` -> `Product.from_fields("anon", dict(...))`. Tuple now refers to heterogenous type indexed by position, e.g. x[0], x[1], ... while Product is used for the key/value version, e.g. x.a, x.y, ... (this was previously namedtuple and tuple supported both integer indexing or key/value)
* `<Tuple>.Ks` -> `<Tuple>.keys()` and `<Tuple>.Ts` -> `<Tuple>.types()` these attributes were refactored to methods to be more clear/consistent with the hwtypes tuple.