### PR TITLE
Add xorr primitive

### DIFF
--- a/mantle/coreir/logic.py
+++ b/mantle/coreir/logic.py
@@ -68,6 +68,9 @@ def DefineCoreirReduceAnd(width):
 
 def DefineCoreirReduceOr(width):
     return DefineCoreirReduce("orr", operator.or_, width)
+
+def DefineCoreirReduceXOr(width):
+    return DefineCoreirReduce("xorr", operator.xor, width)
     # class ReduceAnd(Circuit):
     #     name = f"reduce_and_{width}"
     #     IO = ["I", In(Bits(width)), "O", Out(Bit)]


### PR DESCRIPTION
This adds a hook to call the coreir xorr primitive directly (generates `^in`)