### PR TITLE
Fix ice40 pll

### DIFF
--- a/mantle/lattice/ice40/PLL.py
+++ b/mantle/lattice/ice40/PLL.py
@@ -4,11 +4,11 @@ from magma.backend.verilog import bstr
 __all__ = ['SB_PLL', 'SB_PLL40_CORE']
 
 SB_PLL40_CORE = DeclareCircuit('SB_PLL40_CORE',
-            "REFERENCECLK", In(Bit),
+            "REFERENCECLK", In(Clock),
             "RESETB", In(Bit),
             "BYPASS", In(Bit),
             "PLLOUTCORE", Out(Bit),
-            "PLLOUTGLOBAL", Out(Bit),
+            "PLLOUTGLOBAL", Out(Clock),
             coreir_lib='ice40')
 
 def SB_PLL( freqout, freqin=12000000 ):

--- a/tests/test_ice40/gold/test_pll.json
+++ b/tests/test_ice40/gold/test_pll.json
@@ -1,0 +1,43 @@
+{"top":"global.TestPLL",
+"namespaces":{
+  "global":{
+    "modules":{
+      "SB_PLL40_CORE":{
+        "type":["Record",[
+          ["REFERENCECLK",["Named","coreir.clkIn"]],
+          ["RESETB","BitIn"],
+          ["BYPASS","BitIn"],
+          ["PLLOUTCORE","Bit"],
+          ["PLLOUTGLOBAL",["Named","coreir.clk"]]
+        ]]
+      },
+      "TestPLL":{
+        "type":["Record",[
+          ["CLKIN",["Named","coreir.clkIn"]],
+          ["CLKOUT",["Named","coreir.clk"]]
+        ]],
+        "instances":{
+          "SB_PLL40_CORE_inst0":{
+            "modref":"ice40.SB_PLL40_CORE",
+            "modargs":{"DIVF":[["BitVector",7],"7'h3f"], "DIVQ":[["BitVector",3],"3'h5"], "DIVR":[["BitVector",4],"4'h0"], "FEEDBACK_PATH":["String","SIMPLE"], "FILTER_RANGE":[["BitVector",3],"3'h1"], "PLLOUT_SELECT":["String","GENCLK"]}
+          },
+          "bit_const_0_None":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",false]}
+          },
+          "bit_const_1_None":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",true]}
+          }
+        },
+        "connections":[
+          ["bit_const_0_None.out","SB_PLL40_CORE_inst0.BYPASS"],
+          ["self.CLKOUT","SB_PLL40_CORE_inst0.PLLOUTGLOBAL"],
+          ["self.CLKIN","SB_PLL40_CORE_inst0.REFERENCECLK"],
+          ["bit_const_1_None.out","SB_PLL40_CORE_inst0.RESETB"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_ice40/test_pll.py
+++ b/tests/test_ice40/test_pll.py
@@ -1,0 +1,13 @@
+import magma as m
+from mantle.lattice.ice40 import SB_PLL
+from magma.testing import check_files_equal
+
+def test_pll():
+    class TestPLL(m.Circuit):
+        io = m.IO(CLKIN=m.In(m.Clock),
+                  CLKOUT=m.Out(m.Clock))
+        clk = SB_PLL(32000000, 16000000)(I=io.CLKIN)
+        m.wire(clk, io.CLKOUT)
+
+    m.compile("build/test_pll", TestPLL, output="coreir")
+    assert check_files_equal(__file__, "build/test_pll.json", "gold/test_pll.json")


### PR DESCRIPTION
fix port types

    ERROR: TestPLL: Cannot wire together
      coreir_wrapInClock_inst0.out : Bit
      SB_PLL40_CORE_inst0.REFERENCECLK : coreir.clkIn